### PR TITLE
Support Additional Item Types

### DIFF
--- a/source/Helpers/POETradeAPI/Models/QueryRequest.cs
+++ b/source/Helpers/POETradeAPI/Models/QueryRequest.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sidekick.Helpers.POETradeAPI.Models
 {
@@ -98,6 +99,34 @@ namespace Sidekick.Helpers.POETradeAPI.Models
         public Dictionary<string, SortType> Sort { get; set; } = new Dictionary<string, SortType> { { "price", SortType.Asc } };
     }
 
+    public class BulkQueryRequest
+    {
+
+        public BulkQueryRequest()
+        {
+
+        }
+
+        public BulkQueryRequest(Item item)
+        {
+            var itemType = item.GetType();
+
+            if (itemType == typeof(CurrencyItem))
+            {
+                var itemId = TradeClient.StaticItemCategories.Single(x => x.Id == "Currency")
+                                                               .Entries
+                                                               .Single(x => x.Text == item.Name)
+                                                               .Id;
+
+                Exchange.Want.Add(itemId);
+                Exchange.Have.Add("chaos"); // TODO: Add support for other currency types?
+            }
+        }
+
+        public Exchange Exchange { get; set; } = new Exchange();
+        public Dictionary<string, SortType> Sort { get; set; } = new Dictionary<string, SortType> { { "price", SortType.Asc } };
+    }
+
     public class Query
     {
         public Status Status { get; set; } = new Status();
@@ -105,6 +134,13 @@ namespace Sidekick.Helpers.POETradeAPI.Models
         public string Type { get; set; }
         public List<Stat> Stats { get; set; } = new List<Stat>();
         public Filters Filters { get; set; } = new Filters();
+    }
+
+    public class Exchange
+    {
+        public List<string> Want { get; set; } = new List<string>();
+        public List<string> Have { get; set; } = new List<string>();
+        public string Status = "online";
     }
 
     public class Status

--- a/source/Helpers/POETradeAPI/Models/QueryResult.cs
+++ b/source/Helpers/POETradeAPI/Models/QueryResult.cs
@@ -8,5 +8,6 @@ namespace Sidekick.Helpers.POETradeAPI.Models
         public string Id { get; set; }
         public int Total { get; set; }
         public Item Item { get; set; }
+        public string Uri { get; set; }
     }
 }

--- a/source/Windows/Overlay/UserControls/QueryResultControl.xaml
+++ b/source/Windows/Overlay/UserControls/QueryResultControl.xaml
@@ -54,7 +54,7 @@
         </TextBox>
 
         <TextBlock Grid.Row="1" Grid.Column="0">
-            <Hyperlink NavigateUri="{Binding Id}" RequestNavigate="openQueryLink" TextDecorations="None">
+            <Hyperlink NavigateUri="{Binding Uri}" RequestNavigate="openQueryLink" TextDecorations="None">
                 <TextBlock Grid.Row="1" Margin="8 0 0 5" TextDecorations="Underline">
                     <TextBlock.Text>
                         <MultiBinding StringFormat="{}Showing {0} items out of {1}">

--- a/source/Windows/Overlay/UserControls/QueryResultControl.xaml.cs
+++ b/source/Windows/Overlay/UserControls/QueryResultControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Sidekick.Helpers.POETradeAPI;
+﻿using Sidekick.Helpers;
+using Sidekick.Helpers.POETradeAPI;
 using System.Diagnostics;
 using System.Windows.Controls;
 using System.Windows.Navigation;
@@ -14,7 +15,8 @@ namespace Sidekick.Windows.Overlay.UserControls
 
         private void openQueryLink(object sender, RequestNavigateEventArgs e)
         {
-            var uri = TradeClient.POE_TRADE_SEARCH_BASE_URL + TradeClient.SelectedLeague.Id + "/" + e.Uri;
+            string uri = e.Uri.ToString();
+            Logger.Log(string.Format("Opening in browser: {0}", uri));
             Process.Start(new ProcessStartInfo(uri));
             e.Handled = true;
         }


### PR DESCRIPTION
Fixes #12.

- Added code to allow querying the bulk exchange.
- Added support for currency searches (including splinters, fossils, resonators, essences, catalysts, oils), currently only supports searching listings in chaos.
- Added support for normal items, this includes normal equipment, non-currency fragments, scarabs, partial support for maps (does not check map tier, does not work for blighted maps).
