### PR TITLE
Add dynamic league selection menu to tray icon

### DIFF
--- a/source/Helpers/POETradeAPI/TradeClient.cs
+++ b/source/Helpers/POETradeAPI/TradeClient.cs
@@ -30,6 +30,8 @@ namespace Sidekick.Helpers.POETradeAPI
 
         public static bool IsReady;
 
+        public static League SelectedLeague;
+
         public static async void Initialize()
         {
             if (_jsonSerializerSettings == null)
@@ -70,6 +72,9 @@ namespace Sidekick.Helpers.POETradeAPI
             }
 
             IsFetching = false;
+
+            TrayIcon.PopulateLeagueSelectMenu(Leagues);
+
             IsReady = true;
 
             Logger.Log($"Path of Exile trade data fetched.");
@@ -121,7 +126,7 @@ namespace Sidekick.Helpers.POETradeAPI
             {
                 var queryRequest = new QueryRequest(item);
                 var body = new StringContent(JsonConvert.SerializeObject(queryRequest, _jsonSerializerSettings), Encoding.UTF8, "application/json");
-                var response = await _httpClient.PostAsync("search/Metamorph", body);
+                var response = await _httpClient.PostAsync("search/"+SelectedLeague.Id, body);
                 if (response.IsSuccessStatusCode)
                 {
                     var content = await response.Content.ReadAsStringAsync();

--- a/source/Helpers/TrayIcon.cs
+++ b/source/Helpers/TrayIcon.cs
@@ -1,11 +1,16 @@
-﻿using Sidekick.Windows.ApplicationLogs;
+﻿using Sidekick.Helpers.POETradeAPI.Models.TradeData;
+using Sidekick.Helpers.POETradeAPI;
+using Sidekick.Windows.ApplicationLogs;
+using System.Collections.Generic;
 using System.Windows.Forms;
+
 
 namespace Sidekick.Helpers
 {
     public static class TrayIcon
     {
         static private NotifyIcon _notifyIcon;
+        static private ToolStripMenuItem _leagueSelectMenu;
 
         public static void Initialize()
         {
@@ -15,9 +20,24 @@ namespace Sidekick.Helpers
             _notifyIcon.Text = "Sidekick";
 
             var contextMenu = new ContextMenuStrip();
+            _leagueSelectMenu = new ToolStripMenuItem("League");
+            contextMenu.Items.Add(_leagueSelectMenu);
+            contextMenu.Items.Add(new ToolStripSeparator());
             contextMenu.Items.Add("Show logs", null, (s, e) => ApplicationLogsController.Show());
             contextMenu.Items.Add("Exit", null, (s, e) => Application.Exit());
             _notifyIcon.ContextMenuStrip = contextMenu;
+        }
+
+        public static void PopulateLeagueSelectMenu(List<League> leagues) {
+            foreach(League l in leagues) {
+                var menuItem = new ToolStripMenuItem(l.Id);
+                menuItem.Click += (s, e) => { foreach (ToolStripMenuItem t in _leagueSelectMenu.DropDownItems) { t.Checked = false; } };
+                menuItem.Click += (s, e) => { menuItem.Checked = true; };
+                menuItem.Click += (s, e) => { TradeClient.SelectedLeague = l; };
+                _leagueSelectMenu.DropDownItems.Add(menuItem);
+            }
+            //select the first league as the default
+            _leagueSelectMenu.DropDownItems[0].PerformClick();
         }
 
         public static void SendNotification(string text, string title = null)

--- a/source/Windows/Overlay/UserControls/QueryResultControl.xaml.cs
+++ b/source/Windows/Overlay/UserControls/QueryResultControl.xaml.cs
@@ -14,7 +14,7 @@ namespace Sidekick.Windows.Overlay.UserControls
 
         private void openQueryLink(object sender, RequestNavigateEventArgs e)
         {
-            var uri = TradeClient.POE_TRADE_SEARCH_BASE_URL + TradeClient.Leagues[0].Id + "/" + e.Uri;
+            var uri = TradeClient.POE_TRADE_SEARCH_BASE_URL + TradeClient.SelectedLeague.Id + "/" + e.Uri;
             Process.Start(new ProcessStartInfo(uri));
             e.Handled = true;
         }


### PR DESCRIPTION
Populates a submenu in the existing tray menu with the fetched leagues, allowing users to select their desired one. Also updates the clickable link in the query result popup.

Fixes #6, although without a proper settings screen.