### PR TITLE
GetLinkCount bug

### DIFF
--- a/source/Helpers/ItemParser.cs
+++ b/source/Helpers/ItemParser.cs
@@ -168,8 +168,16 @@ namespace Sidekick.Helpers
             {
                 return 0;
             }
-
-            return input.Count(c => c == '-') == 0 ? 0 : input.Count(c => c == '-') + 1;
+            List<int> values = new List<int>();
+            if (!String.IsNullOrEmpty(input))
+            {
+                foreach (string fragment in input.Split(' '))
+                {
+                    values.Add(fragment.Count(c => c == '-') == 0 ? 0 : fragment.Count(c => c == '-') + 1);
+                }
+                return values.Max();
+            }
+            else return 0;
         }
 
         internal static InfluenceType GetInfluenceType(string input)


### PR DESCRIPTION
This function would return the wrong value (5) in cases of items that have 4+2 or 2+4 links
ex. (G-G-G-G G-G)

Fixed by splitting the string and returning the max substring links value using the already existing logic