### PR TITLE
Fix windows scaling causing overlay to display in the wrong position

### DIFF
--- a/source/Helpers/NativeMethods/ProcessHelper.cs
+++ b/source/Helpers/NativeMethods/ProcessHelper.cs
@@ -31,6 +31,14 @@ namespace Sidekick.Helpers.NativeMethods
             return processToCheck?.MainWindowTitle == PATH_OF_EXILE_PROCESS_TITLE;
         }
 
+        public static float GetActiveWindowDpi()
+        {
+            using (Graphics g = Graphics.FromHwnd(GetForegroundWindow()))
+            {
+                return g.DpiX;
+            }
+        }
+
         public static int GetActiveWindowWidth()
         {
             GetWindowRect(GetForegroundWindow(), out Rectangle windowRect);

--- a/source/Sidekick.csproj
+++ b/source/Sidekick.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <TargetFramework>net48</TargetFramework>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <!-- TODO: Add dotnet core support in MouseKeyHook, remove System.Windows.Forms reference, ... profit
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PublishSingleFile>true</PublishSingleFile>

--- a/source/Windows/Overlay/OverlayController.cs
+++ b/source/Windows/Overlay/OverlayController.cs
@@ -1,5 +1,6 @@
-﻿using Sidekick.Helpers.POETradeAPI.Models;
-using System.Collections.Generic;
+﻿using Sidekick.Helpers.NativeMethods;
+using Sidekick.Helpers.POETradeAPI.Models;
+using System;
 using System.Windows;
 
 namespace Sidekick.Windows.Overlay
@@ -29,9 +30,14 @@ namespace Sidekick.Windows.Overlay
 
             // Ensure the window stays inside the screen but still appears on the mouse.
             var screen = SystemParameters.WorkArea;
+            var scale = screen.Width / ProcessHelper.GetActiveWindowWidth();
+            var xScaled = (int)Math.Floor(x * scale);
+            var yScaled = (int)Math.Floor(y * scale);
+
             var padding = 5;
-            var positionX = x + (x < screen.Width / 2 ? padding : -WINDOW_WIDTH - padding);
-            var positionY = y + (y < screen.Height / 2 ? padding : -WINDOW_HEIGHT - padding);
+            var positionX = xScaled + (xScaled < screen.Width / 2 ? padding : -WINDOW_WIDTH - padding);
+            var positionY = yScaled + (yScaled < screen.Height / 2 ? padding : -WINDOW_HEIGHT - padding);
+
 
             _overlayWindow.SetWindowPosition(positionX, positionY);
         }

--- a/source/Windows/Overlay/OverlayController.cs
+++ b/source/Windows/Overlay/OverlayController.cs
@@ -1,7 +1,10 @@
-﻿using Sidekick.Helpers.NativeMethods;
+﻿using Sidekick.Helpers;
+using Sidekick.Helpers.NativeMethods;
 using Sidekick.Helpers.POETradeAPI.Models;
 using System;
+using System.Drawing;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace Sidekick.Windows.Overlay
 {
@@ -10,6 +13,7 @@ namespace Sidekick.Windows.Overlay
         private static OverlayWindow _overlayWindow;
         private static int WINDOW_WIDTH = 480;
         private static int WINDOW_HEIGHT = 320;
+        private static int PADDING = 5;
 
         public static void Initialize()
         {
@@ -29,15 +33,16 @@ namespace Sidekick.Windows.Overlay
                 Initialize();
 
             // Ensure the window stays inside the screen but still appears on the mouse.
-            var screen = SystemParameters.WorkArea;
-            var scale = screen.Width / ProcessHelper.GetActiveWindowWidth();
-            var xScaled = (int)Math.Floor(x * scale);
-            var yScaled = (int)Math.Floor(y * scale);
+            var scale = 96f / ProcessHelper.GetActiveWindowDpi();
+            var screenRect = Screen.FromPoint(Cursor.Position).Bounds;
 
-            var padding = 5;
-            var positionX = xScaled + (xScaled < screen.Width / 2 ? padding : -WINDOW_WIDTH - padding);
-            var positionY = yScaled + (yScaled < screen.Height / 2 ? padding : -WINDOW_HEIGHT - padding);
+            var xScaled = (int)(x * scale);
+            var yScaled = (int)(y * scale);
+            var xMidScaled = (screenRect.X + (screenRect.Width / 2)) * scale;
+            var yMidScaled = (screenRect.Y + (screenRect.Height / 2)) * scale;
 
+            var positionX = xScaled + (xScaled < xMidScaled ? PADDING : -WINDOW_WIDTH - PADDING);
+            var positionY = yScaled + (yScaled < yMidScaled ? PADDING : -WINDOW_HEIGHT - PADDING);
 
             _overlayWindow.SetWindowPosition(positionX, positionY);
         }

--- a/source/app.manifest
+++ b/source/app.manifest
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Fixes #36.

Works for every combination I've tried but should probably be tested by people with different screen setups as well.