### PR TITLE
Add influence type to normal and rare item query

### DIFF
--- a/source/Helpers/ItemParser.cs
+++ b/source/Helpers/ItemParser.cs
@@ -19,7 +19,7 @@ namespace Sidekick.Helpers
         public static Item ParseItem(string text)
         {
             Item item = null;
-            bool isIdentified, hasQuality, isCorrupted, isMap, isBlighted;
+            bool isIdentified, hasQuality, isCorrupted, isMap, isBlighted, hasNote;
 
             try
             {
@@ -32,6 +32,7 @@ namespace Sidekick.Helpers
                 isCorrupted = lines.Any(x => x == LanguageSettings.Provider.DescriptionCorrupted);
                 isMap = lines.Any(x => x.Contains(LanguageSettings.Provider.DescriptionMapTier));
                 isBlighted = lines.Any(x => x.Contains(LanguageSettings.Provider.PrefixBlighted));
+                hasNote = lines.LastOrDefault().Contains("Note");
 
                 var rarity = lines[0].Replace(LanguageSettings.Provider.DescriptionRarity, string.Empty);
 
@@ -114,9 +115,14 @@ namespace Sidekick.Helpers
                         };
                     }
 
-                    var influence = GetInfluenceType(lines.LastOrDefault());
-
-                    ((EquippableItem)item).Influence = influence;
+                    if (hasNote)
+                    {
+                        ((EquippableItem)item).Influence = GetInfluenceType(lines[lines.Length - 3]);
+                    }
+                    else
+                    {
+                        ((EquippableItem)item).Influence = GetInfluenceType(lines.LastOrDefault());
+                    }
                 }
                 else if(rarity == LanguageSettings.Provider.RarityMagic)
                 {
@@ -133,8 +139,14 @@ namespace Sidekick.Helpers
                             ItemLevel = GetNumberFromString(lines.Where(c => c.StartsWith(LanguageSettings.Provider.DescriptionItemLevel)).FirstOrDefault()),
                         };
 
-                        var influence = GetInfluenceType(lines.LastOrDefault());
-                        ((EquippableItem)item).Influence = influence;
+                        if (hasNote)
+                        {
+                            ((EquippableItem)item).Influence = GetInfluenceType(lines[lines.Length - 3]);
+                        }
+                        else
+                        {
+                            ((EquippableItem)item).Influence = GetInfluenceType(lines.LastOrDefault());
+                        }
 
                         var links = GetLinkCount(lines.Where(c => c.StartsWith(LanguageSettings.Provider.DescriptionSockets)).FirstOrDefault());
 

--- a/source/Helpers/POETradeAPI/Models/QueryRequest.cs
+++ b/source/Helpers/POETradeAPI/Models/QueryRequest.cs
@@ -50,6 +50,48 @@ namespace Sidekick.Helpers.POETradeAPI.Models
                     {
                         Option = ((EquippableItem)item).Rarity.ToLowerInvariant(),
                     };
+
+                    switch (((EquippableItem)item).Influence)
+                    {
+                        case InfluenceType.None:
+                            break;
+                        case InfluenceType.Shaper:
+                            Query.Filters.MiscFilters.Filters.ShaperItem = new FilterOption()
+                            {
+                                Option = "true"
+                            };
+                            break;
+                        case InfluenceType.Crusader:
+                            Query.Filters.MiscFilters.Filters.CrusaderItem = new FilterOption()
+                            {
+                                Option = "true"
+                            };
+                            break;
+                        case InfluenceType.Elder:
+                            Query.Filters.MiscFilters.Filters.ElderItem = new FilterOption()
+                            {
+                                Option = "true"
+                            };
+                            break;
+                        case InfluenceType.Hunter:
+                            Query.Filters.MiscFilters.Filters.HunterItem = new FilterOption()
+                            {
+                                Option = "true"
+                            };
+                            break;
+                        case InfluenceType.Redeemer:
+                            Query.Filters.MiscFilters.Filters.RedeemerItem = new FilterOption()
+                            {
+                                Option = "true"
+                            };
+                            break;
+                        case InfluenceType.Warlord:
+                            Query.Filters.MiscFilters.Filters.WarlordItem = new FilterOption()
+                            {
+                                Option = "true"
+                            };
+                            break;
+                    }
                 }             
 
                 if(((EquippableItem)item).Links != null)        // Auto Search 5+ Links


### PR DESCRIPTION
- Added influence type to normal and rare item query so it can be used for base price check for now.
- Fixed influence type parsing when item has note.
