### PR TITLE
Sets the min itemlevel to 86 if the itemlevel is above 86

### DIFF
--- a/source/Helpers/POETradeAPI/Models/QueryRequest.cs
+++ b/source/Helpers/POETradeAPI/Models/QueryRequest.cs
@@ -40,11 +40,21 @@ namespace Sidekick.Helpers.POETradeAPI.Models
                         throw new Exception("Couldn't parse Item Level");
                     }
 
-                    Query.Filters.MiscFilters.Filters.ItemLevel = new FilterValue()
+                    if (result >= 86)
                     {
-                        Min = result,
-                        Max = result,
-                    };
+                        Query.Filters.MiscFilters.Filters.ItemLevel = new FilterValue()
+                        {
+                            Min = 86
+                        };
+                    }
+                    else
+                    {
+                        Query.Filters.MiscFilters.Filters.ItemLevel = new FilterValue()
+                        {
+                            Min = result,
+                            Max = result,
+                        };
+                    }
 
                     Query.Filters.TypeFilter.Filters.Rarity = new FilterOption()
                     {


### PR DESCRIPTION
I added a filter to set the min ilevel to 86 if the item haves an itemlevel above 86.
This is usefull because all items above ilevel 86 are treated the same from the community.