### PR TITLE
Fix mouse lag that occurs after exiting

### DIFF
--- a/source/Helpers/Input/EventsHandler.cs
+++ b/source/Helpers/Input/EventsHandler.cs
@@ -22,7 +22,7 @@ namespace Sidekick.Helpers
         {
             _globalHook = Hook.GlobalEvents();
             _globalHook.KeyDown += GlobalHookKeyPressHandler;
-            //_globalHook.MouseWheelExt += GlobalHookMouseScrollHandler;
+            _globalHook.MouseWheelExt += GlobalHookMouseScrollHandler;
 
             // #TODO: Remap all actions to json read local file for allowing user bindings
             var exit = Sequence.FromString("Shift+Z, Shift+Z");
@@ -172,7 +172,12 @@ namespace Sidekick.Helpers
 
         public static void Dispose()
         {
-            _globalHook?.Dispose();
+            if (_globalHook != null)
+            {
+                _globalHook.KeyDown -= GlobalHookKeyPressHandler;
+                _globalHook.MouseWheelExt -= GlobalHookMouseScrollHandler;
+                _globalHook.Dispose();
+            }
         }
     }
 }

--- a/source/Program.cs
+++ b/source/Program.cs
@@ -35,16 +35,20 @@ namespace Sidekick
             OverlayController.Initialize();
 
             // Run window.
-            Application.ApplicationExit += OnApplicationExit;
+            Application.ThreadExit += ThreadExit;
             Application.Run();
         }
 
-        private static void OnApplicationExit(object sender, EventArgs e)
+        private static void ThreadExit(object sender, EventArgs e)
         {
-            TrayIcon.Dispose();
-            TradeClient.Dispose();
-            EventsHandler.Dispose();
-            OverlayController.Dispose();
+            // check that the main thread is about to exit
+            if (SynchronizationContext.Current != null)
+            {
+                TrayIcon.Dispose();
+                TradeClient.Dispose();
+                EventsHandler.Dispose();
+                OverlayController.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
The ThreadExit event fires before ApplicationExit, and using this instead for disposal seems to fix the mouse lag after exiting for me.

This PR also reenables the mouse wheel hook, which seems to have been inadvertently disabled. 

#30 is somewhat related. 