### PR TITLE
Refactor initialization process

### DIFF
--- a/src/Sidekick.Business/StartupExtensions.cs
+++ b/src/Sidekick.Business/StartupExtensions.cs
@@ -10,6 +10,7 @@ using Sidekick.Business.Parsers;
 using Sidekick.Business.Tokenizers;
 using Sidekick.Business.Tokenizers.ItemName;
 using Sidekick.Business.Trades;
+using Sidekick.Core;
 
 namespace Sidekick.Business
 {
@@ -17,18 +18,19 @@ namespace Sidekick.Business
     {
         public static IServiceCollection AddSidekickBusinessServices(this IServiceCollection services)
         {
-            services.AddSingleton<IAttributeCategoryService, AttributeCategoryService>();
             services.AddSingleton<IHttpClientProvider, HttpClientProvider>();
-            services.AddSingleton<IItemCategoryService, ItemCategoryService>();
             services.AddSingleton<IItemParser, ItemParser>();
             services.AddSingleton<ILanguageProvider, LanguageProvider>();
-            services.AddSingleton<ILeagueService, LeagueService>();
-            services.AddSingleton<IMapService, MapService>();
             services.AddSingleton<IPoeApiService, PoeApiService>();
-            services.AddSingleton<IStaticItemCategoryService, StaticItemCategoryService>();
             services.AddSingleton<ITokenizer, ItemNameTokenizer>();
             services.AddSingleton<ITradeClient, TradeClient>();
             services.AddSingleton<IUILanguageProvider, UILanguageProvider>();
+
+            services.AddInitializableService<IAttributeCategoryService, AttributeCategoryService>();
+            services.AddInitializableService<IItemCategoryService, ItemCategoryService>();
+            services.AddInitializableService<ILeagueService, LeagueService>();
+            services.AddInitializableService<IMapService, MapService>();
+            services.AddInitializableService<IStaticItemCategoryService, StaticItemCategoryService>();
 
             return services;
         }

--- a/src/Sidekick.Core/StartupExtensions.cs
+++ b/src/Sidekick.Core/StartupExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Sidekick.Core.Initialization;
 using Sidekick.Core.Loggers;
@@ -8,10 +11,38 @@ namespace Sidekick.Core
     {
         public static IServiceCollection AddSidekickCoreServices(this IServiceCollection services)
         {
-            services.AddSingleton<ILogger, Logger>();
             services.AddSingleton<IInitializer, Initializer>();
+            services.AddInitializableService<ILogger, Logger>();
 
             return services;
+        }
+
+        private static readonly HashSet<Type> intializeTypes = new HashSet<Type>
+        {
+            typeof(IOnReset),
+            typeof(IOnBeforeInit),
+            typeof(IOnInit),
+            typeof(IOnAfterInit)
+        };
+
+
+        /// <summary>
+        /// Registers a singleton service, along with any intializatation interfaces the implementation type also implements.
+        /// Required for integration with <see cref="IInitializer"/>.
+        /// </summary>
+        /// <typeparam name="TInterface"></typeparam>
+        /// <typeparam name="TImplementation"></typeparam>
+        /// <param name="services"></param>
+        public static void AddInitializableService<TInterface, TImplementation>(this IServiceCollection services)
+            where TInterface : class
+            where TImplementation : class, TInterface
+        {
+            services.AddSingleton<TInterface, TImplementation>();
+
+            foreach (var initializeInterface in typeof(TImplementation).GetInterfaces().Where(i => intializeTypes.Contains(i)))
+            {
+                services.AddSingleton(initializeInterface, serviceProvider => serviceProvider.GetRequiredService<TInterface>());
+            }
         }
     }
 }


### PR DESCRIPTION
My opinion is that making a service part of the initialization flow should be a clear choice rather than a somewhat obscured side effect of adding an interface to a class.

I have introduced the `AddInitializableService` extension method to be used when registering services. This gives a better overview of what services are part of the initialization and (in my opinion) improves readability for new contributors.

Related to #97 