### PR TITLE
Fixed small bug with binding to localizable resources

### DIFF
--- a/src/Sidekick.Localization/TranslationSource.cs
+++ b/src/Sidekick.Localization/TranslationSource.cs
@@ -7,7 +7,7 @@ namespace Sidekick.Localization
 {
     public class TranslationSource : INotifyPropertyChanged
     {
-        public static TranslationSource Instance => new TranslationSource();
+        public static TranslationSource Instance { get; } = new TranslationSource();
 
         private readonly Dictionary<string, ResourceManager> resourceManagerDictionary = new Dictionary<string, ResourceManager>();
 


### PR DESCRIPTION
I accidentally broke the binding functionality when doing some last minute cleanup on #226 before submitting the PR. 