### PR TITLE
Localized resource bindings for all views

### DIFF
--- a/src/Sidekick.Localization/IUILanguageProvider.cs
+++ b/src/Sidekick.Localization/IUILanguageProvider.cs
@@ -6,11 +6,7 @@ namespace Sidekick.Localization
 {
     public interface IUILanguageProvider
     {
-        CultureInfo Current { get; }
-
         List<CultureInfo> AvailableLanguages { get; }
-
-        event Action UILanguageChanged;
 
         void SetLanguage(string name);
     }

--- a/src/Sidekick.Localization/UILanguageProvider.cs
+++ b/src/Sidekick.Localization/UILanguageProvider.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using Sidekick.Core.Settings;
 
 namespace Sidekick.Localization
@@ -10,8 +9,6 @@ namespace Sidekick.Localization
     public class UILanguageProvider : IUILanguageProvider
     {
         private static string[] SupportedLanguages = new[] { "en", "fr", "de", "zh-tw" };
-
-        public event Action UILanguageChanged;
 
         public UILanguageProvider(SidekickSettings settings)
         {
@@ -32,22 +29,9 @@ namespace Sidekick.Localization
 
         public List<CultureInfo> AvailableLanguages { get; private set; }
 
-        public CultureInfo Current { get; private set; }
-
         public void SetLanguage(string name)
         {
-            Current = new CultureInfo(name);
-            Thread.CurrentThread.CurrentCulture = Current;
-            Thread.CurrentThread.CurrentUICulture = Current;
-
-
-            if (UILanguageChanged != null)
-            {
-                UILanguageChanged.Invoke();
-            }
-
-            // Keeping the old implementation above until all views bind directly to localized resources
-            TranslationSource.Instance.CurrentCulture = Current;
+            TranslationSource.Instance.CurrentCulture = new CultureInfo(name);
         }
     }
 }

--- a/src/Sidekick.UI/Views/ViewLocator.cs
+++ b/src/Sidekick.UI/Views/ViewLocator.cs
@@ -24,11 +24,9 @@ namespace Sidekick.UI.Views
         public void Open<TView>()
             where TView : ISidekickView
         {
-            var uiLanguageProvider = serviceProvider.GetService<IUILanguageProvider>();
-
-            var cultureInfo = new CultureInfo(uiLanguageProvider.Current.Name);
-            Thread.CurrentThread.CurrentCulture = cultureInfo;
-            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            // Still needed for localization of league overlay models
+            Thread.CurrentThread.CurrentCulture = TranslationSource.Instance.CurrentCulture;
+            Thread.CurrentThread.CurrentUICulture = TranslationSource.Instance.CurrentCulture;
 
             var view = new ViewInstance(
                 serviceProvider.CreateScope(),

--- a/src/Sidekick/Windows/Leagues/Betrayal/League.xaml
+++ b/src/Sidekick/Windows/Leagues/Betrayal/League.xaml
@@ -4,7 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:league="clr-namespace:Sidekick.Windows.Leagues"
     xmlns:local="clr-namespace:Sidekick.Windows.Leagues.Betrayal"
-    xmlns:r="clr-namespace:Sidekick.Localization.Leagues.Betrayal;assembly=Sidekick.Localization">
+    xmlns:resx="clr-namespace:Sidekick.Localization.Leagues.Betrayal;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:BetrayalResources.ResourceManager}">
+    
     <UserControl.Resources>
         <ResourceDictionary Source="/Styles/Main.xaml" />
     </UserControl.Resources>
@@ -16,28 +19,28 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     FontSize="30"
-                    Text="{x:Static r:BetrayalResources.TypeTransportation}" />
+                    Text="{loc:Loc TypeTransportation}" />
             </Border>
             <Border MinHeight="60">
                 <TextBlock
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     FontSize="30"
-                    Text="{x:Static r:BetrayalResources.TypeFortification}" />
+                    Text="{loc:Loc TypeFortification}" />
             </Border>
             <Border MinHeight="60">
                 <TextBlock
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     FontSize="30"
-                    Text="{x:Static r:BetrayalResources.TypeResearch}" />
+                    Text="{loc:Loc TypeResearch}" />
             </Border>
             <Border MinHeight="60">
                 <TextBlock
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     FontSize="30"
-                    Text="{x:Static r:BetrayalResources.TypeIntervention}" />
+                    Text="{loc:Loc TypeIntervention}" />
             </Border>
         </StackPanel>
         <StackPanel>

--- a/src/Sidekick/Windows/Leagues/Delve/League.xaml
+++ b/src/Sidekick/Windows/Leagues/Delve/League.xaml
@@ -6,7 +6,9 @@
     xmlns:league="clr-namespace:Sidekick.Windows.Leagues"
     xmlns:local="clr-namespace:Sidekick.Windows.Leagues.Delve"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:r="clr-namespace:Sidekick.Localization.Leagues.Delve;assembly=Sidekick.Localization"
+    xmlns:resx="clr-namespace:Sidekick.Localization.Leagues.Delve;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:DelveResources.ResourceManager}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
@@ -31,7 +33,7 @@
         </ItemsControl>
         <WrapPanel>
             <league:Legend />
-            <TextBlock VerticalAlignment="Center" Text="{x:Static r:DelveResources.Information}" />
+            <TextBlock VerticalAlignment="Center" Text="{loc:Loc Information}" />
         </WrapPanel>
     </StackPanel>
 </UserControl>

--- a/src/Sidekick/Windows/Leagues/Incursion/League.xaml
+++ b/src/Sidekick/Windows/Leagues/Incursion/League.xaml
@@ -6,7 +6,9 @@
     xmlns:league="clr-namespace:Sidekick.Windows.Leagues"
     xmlns:local="clr-namespace:Sidekick.Windows.Leagues.Incursion"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:r="clr-namespace:Sidekick.Localization.Leagues.Incursion;assembly=Sidekick.Localization"
+    xmlns:resx="clr-namespace:Sidekick.Localization.Leagues.Incursion;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:IncursionResources.ResourceManager}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
@@ -21,23 +23,23 @@
                     <TextBlock
                         Width="125"
                         Padding="{StaticResource Spacer}"
-                        Text="{x:Static r:IncursionResources.Level1}" />
+                        Text="{loc:Loc Level1}" />
                     <TextBlock
                         Width="125"
                         Padding="{StaticResource Spacer}"
-                        Text="{x:Static r:IncursionResources.Level2}" />
+                        Text="{loc:Loc Level2}" />
                     <TextBlock
                         Width="125"
                         Padding="{StaticResource Spacer}"
-                        Text="{x:Static r:IncursionResources.Level3}" />
+                        Text="{loc:Loc Level3}" />
                     <TextBlock
                         Width="250"
                         Padding="{StaticResource Spacer}"
-                        Text="{x:Static r:IncursionResources.Contains}" />
+                        Text="{loc:Loc Contains}" />
                     <TextBlock
                         Width="250"
                         Padding="{StaticResource Spacer}"
-                        Text="{x:Static r:IncursionResources.Modifiers}" />
+                        Text="{loc:Loc Modifiers}" />
                 </StackPanel>
             </GroupBox.Header>
             <ItemsControl ItemsSource="{Binding Path=Model.Rooms}">

--- a/src/Sidekick/Windows/Leagues/LeagueView.xaml
+++ b/src/Sidekick/Windows/Leagues/LeagueView.xaml
@@ -10,7 +10,9 @@
     xmlns:incursion="clr-namespace:Sidekick.Windows.Leagues.Incursion"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:metamorph="clr-namespace:Sidekick.Windows.Leagues.Metamorph"
-    xmlns:r="clr-namespace:Sidekick.Localization.Leagues;assembly=Sidekick.Localization"
+    xmlns:resx="clr-namespace:Sidekick.Localization.Leagues;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:LeagueResources.ResourceManager}"
     SizeToContent="WidthAndHeight"
     mc:Ignorable="d">
     <Window.Resources>
@@ -22,19 +24,19 @@
     </Window.Style>
 
     <TabControl>
-        <TabItem Header="{x:Static r:LeagueResources.LeagueNameBetrayal}">
+        <TabItem Header="{loc:Loc LeagueNameBetrayal}">
             <betrayal:League Model="{Binding Betrayal}" />
         </TabItem>
-        <TabItem Header="{x:Static r:LeagueResources.LeagueNameBlight}">
+        <TabItem Header="{loc:Loc LeagueNameBlight}">
             <blight:League Model="{Binding Blight}" />
         </TabItem>
-        <TabItem Header="{x:Static r:LeagueResources.LeagueNameDelve}">
+        <TabItem Header="{loc:Loc LeagueNameDelve}">
             <delve:League Model="{Binding Delve}" />
         </TabItem>
-        <TabItem Header="{x:Static r:LeagueResources.LeagueNameIncrusion}">
+        <TabItem Header="{loc:Loc LeagueNameIncrusion}">
             <incursion:League Model="{Binding Incursion}" />
         </TabItem>
-        <TabItem Header="{x:Static r:LeagueResources.LeagueNameMetamorph}">
+        <TabItem Header="{loc:Loc LeagueNameMetamorph}">
             <metamorph:League Model="{Binding Metamorph}" />
         </TabItem>
     </TabControl>

--- a/src/Sidekick/Windows/Leagues/Legend.xaml
+++ b/src/Sidekick/Windows/Leagues/Legend.xaml
@@ -4,7 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:r="clr-namespace:Sidekick.Localization.Leagues;assembly=Sidekick.Localization"
+    xmlns:resx="clr-namespace:Sidekick.Localization.Leagues;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:LeagueResources.ResourceManager}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
@@ -18,28 +20,28 @@
             Padding="2"
             BorderBrush="{Binding LowColor}"
             BorderThickness="4,0,0,0">
-            <TextBlock Text="{x:Static r:LeagueResources.LegendNotValuable}" />
+            <TextBlock Text="{loc:Loc LegendNotValuable}" />
         </Border>
         <Border
             Margin="{StaticResource SpacerRight}"
             Padding="2"
             BorderBrush="{Binding NormalColor}"
             BorderThickness="4,0,0,0">
-            <TextBlock Text="{x:Static r:LeagueResources.LegendLessValuable}" />
+            <TextBlock Text="{loc:Loc LegendLessValuable}" />
         </Border>
         <Border
             Margin="{StaticResource SpacerRight}"
             Padding="2"
             BorderBrush="{Binding HighColor}"
             BorderThickness="4,0,0,0">
-            <TextBlock Text="{x:Static r:LeagueResources.LegendValuable}" />
+            <TextBlock Text="{loc:Loc LegendValuable}" />
         </Border>
         <Border
             Margin="{StaticResource SpacerRight}"
             Padding="2"
             BorderBrush="{Binding VeryHighColor}"
             BorderThickness="4,0,0,0">
-            <TextBlock Text="{x:Static r:LeagueResources.LegendMoreValuable}" />
+            <TextBlock Text="{loc:Loc LegendMoreValuable}" />
         </Border>
     </StackPanel>
 </UserControl>

--- a/src/Sidekick/Windows/PriceCheck/OverlayView.xaml
+++ b/src/Sidekick/Windows/PriceCheck/OverlayView.xaml
@@ -3,7 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:VM="clr-namespace:Sidekick.Windows.PriceCheck.ViewModels"
-    xmlns:r="clr-namespace:Sidekick.Localization.PriceCheck;assembly=Sidekick.Localization"
+    xmlns:resx="clr-namespace:Sidekick.Localization.PriceCheck;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:PriceCheckResources.ResourceManager}"
     SizeToContent="WidthAndHeight">
     <Window.Resources>
         <ResourceDictionary>
@@ -78,23 +80,23 @@
                         <GridViewColumn
                             Width="140"
                             DisplayMemberBinding="{Binding Path=AccountName}"
-                            Header="{x:Static r:PriceCheckResources.OverlayAccountName}" />
+                            Header="{loc:Loc OverlayAccountName}" />
                         <GridViewColumn
                             Width="140"
                             DisplayMemberBinding="{Binding Path=CharacterName}"
-                            Header="{x:Static r:PriceCheckResources.OverlayCharacter}" />
+                            Header="{loc:Loc OverlayCharacter}" />
                         <GridViewColumn
                             Width="80"
                             DisplayMemberBinding="{Binding Path=Price}"
-                            Header="{x:Static r:PriceCheckResources.OverlayPrice}" />
+                            Header="{loc:Loc OverlayPrice}" />
                         <GridViewColumn
                             Width="40"
                             DisplayMemberBinding="{Binding Path=ItemLevel}"
-                            Header="{x:Static r:PriceCheckResources.OverlayItemLevel}" />
+                            Header="{loc:Loc OverlayItemLevel}" />
                         <GridViewColumn
                             Width="80"
                             DisplayMemberBinding="{Binding Path=Age}"
-                            Header="{x:Static r:PriceCheckResources.OverlayAge}" />
+                            Header="{loc:Loc OverlayAge}" />
                     </GridView>
                 </ListView.View>
             </ListView>

--- a/src/Sidekick/Windows/PriceCheck/OverlayView.xaml.cs
+++ b/src/Sidekick/Windows/PriceCheck/OverlayView.xaml.cs
@@ -47,10 +47,8 @@ namespace Sidekick.Windows.PriceCheck
         private IPoePriceInfoClient poePriceInfoClient;
         private readonly INativeBrowser nativeBrowser;
 
-        public OverlayWindow(IPoePriceInfoClient poePriceInfoClient, INativeBrowser nativeBrowser, IUILanguageProvider iUILanguageProvider)
+        public OverlayWindow(IPoePriceInfoClient poePriceInfoClient, INativeBrowser nativeBrowser, IUILanguageProvider uiLanguageProvider)
         {
-            Thread.CurrentThread.CurrentCulture =
-            Thread.CurrentThread.CurrentUICulture = iUILanguageProvider.Current;
             this.poePriceInfoClient = poePriceInfoClient;
             this.nativeBrowser = nativeBrowser;
             InitializeComponent();

--- a/src/Sidekick/Windows/Settings/SettingsView.xaml
+++ b/src/Sidekick/Windows/Settings/SettingsView.xaml
@@ -3,7 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:UC="clr-namespace:Sidekick.Windows.Settings.UserControls"
-    xmlns:r="clr-namespace:Sidekick.Localization.Settings;assembly=Sidekick.Localization"
+    xmlns:resx="clr-namespace:Sidekick.Localization.Settings;assembly=Sidekick.Localization"
+    xmlns:loc="clr-namespace:Sidekick.Windows"
+    loc:Translation.ResourceManager="{x:Static resx:SettingResources.ResourceManager}"
     Title="Settings - Sidekick"
     Width="680"
     Height="400"
@@ -17,25 +19,25 @@
         <Style BasedOn="{StaticResource {x:Type Window}}" TargetType="Window" />
     </Window.Style>
 
-    <DockPanel Margin="{StaticResource Spacer}">
+    <DockPanel Margin="{StaticResource Spacer}" >
         <WrapPanel HorizontalAlignment="Right" DockPanel.Dock="Bottom">
-            <Button Click="DiscardChanges_Click" Content="{x:Static r:SettingResources.Cancel}" />
+            <Button Click="DiscardChanges_Click" Content="{loc:Loc Cancel}" />
             <Button
                 Margin="{StaticResource SpacerLeft}"
                 Click="SaveChanges_Click"
-                Content="{x:Static r:SettingResources.Ok}" />
+                Content="{loc:Loc Ok}" />
         </WrapPanel>
         <TabControl Margin="{StaticResource SpacerBottom}" TabStripPlacement="Left">
-            <TabItem Header="{x:Static r:SettingResources.Tab_General}">
+            <TabItem Header="{loc:Loc Tab_General}">
                 <ScrollViewer>
                     <StackPanel>
-                        <GroupBox Header="{x:Static r:SettingResources.Language_Title}">
+                        <GroupBox Header="{loc:Loc Language_Title}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
                                     <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
-                                <Label Content="{x:Static r:SettingResources.Language_UI}" />
+                                <Label Content="{loc:Loc Language_UI}" />
                                 <ComboBox
                                     Grid.Column="1"
                                     DisplayMemberPath="Key"
@@ -44,7 +46,7 @@
                                     SelectedValuePath="Value" />
                             </Grid>
                         </GroupBox>
-                        <GroupBox Header="{x:Static r:SettingResources.Character_Title}">
+                        <GroupBox Header="{loc:Loc Character_Title}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
@@ -54,27 +56,27 @@
                                     <RowDefinition />
                                     <RowDefinition />
                                 </Grid.RowDefinitions>
-                                <Label Content="{x:Static r:SettingResources.Character_League}" />
+                                <Label Content="{loc:Loc Character_League}" />
                                 <ComboBox
                                     Grid.Column="1"
                                     DisplayMemberPath="Key"
                                     ItemsSource="{Binding Path=LeagueOptions}"
                                     SelectedValue="{Binding Path=Settings.LeagueId}"
                                     SelectedValuePath="Value" />
-                                <Label Grid.Row="1" Content="{x:Static r:SettingResources.Character_Name}" />
+                                <Label Grid.Row="1" Content="{loc:Loc Character_Name}" />
                                 <TextBox
                                     Grid.Row="1"
                                     Grid.Column="1"
-                                    Text="{Binding Path=Settings.Character_Name}" />
+                                    Text="{loc:Loc Character_Name}" />
                             </Grid>
                         </GroupBox>
-                        <GroupBox Header="{x:Static r:SettingResources.Wiki_Title}">
+                        <GroupBox Header="{loc:Loc Wiki_Title}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
                                     <ColumnDefinition />
                                 </Grid.ColumnDefinitions>
-                                <Label Content="{x:Static r:SettingResources.Wiki_Preferred}" />
+                                <Label Content="{loc:Loc Wiki_Preferred}" />
                                 <ComboBox
                                     Grid.Column="1"
                                     DisplayMemberPath="Key"
@@ -83,17 +85,17 @@
                                     SelectedValuePath="Value" />
                             </Grid>
                         </GroupBox>
-                        <GroupBox Header="{x:Static r:SettingResources.Other_Title}">
+                        <GroupBox Header="{loc:Loc Other_Title}">
                             <StackPanel>
-                                <CheckBox Content="{x:Static r:SettingResources.Other_RetainClipboard}" IsChecked="{Binding Path=Settings.RetainClipboard}" />
-                                <CheckBox Content="{x:Static r:SettingResources.Other_CloseWithMouseClick}" IsChecked="{Binding Path=Settings.CloseOverlayWithMouse}" />
-                                <CheckBox Content="{x:Static r:SettingResources.Other_TabScroll}" IsChecked="{Binding Path=Settings.EnableCtrlScroll}" />
+                                <CheckBox Content="{loc:Loc Other_RetainClipboard}" IsChecked="{Binding Path=Settings.RetainClipboard}" />
+                                <CheckBox Content="{loc:Loc Other_CloseWithMouseClick}" IsChecked="{Binding Path=Settings.CloseOverlayWithMouse}" />
+                                <CheckBox Content="{loc:Loc SettingResources.Other_TabScroll}" IsChecked="{Binding Path=Settings.EnableCtrlScroll}" />
                             </StackPanel>
                         </GroupBox>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>
-            <TabItem Header="{x:Static r:SettingResources.Tab_Keybindings}">
+            <TabItem Header="{loc:Loc Tab_Keybindings}">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <ItemsControl ItemsSource="{Binding Path=Keybinds}">
                         <ItemsControl.ItemTemplate>

--- a/src/Sidekick/Windows/TranslationDependencyProperty.cs
+++ b/src/Sidekick/Windows/TranslationDependencyProperty.cs
@@ -67,7 +67,7 @@ namespace Sidekick.Windows
 
             if (string.IsNullOrEmpty(baseName))
             {
-                var parentObject = (targetObject as ItemsControl).Parent;
+                var parentObject = (targetObject as ItemsControl)?.Parent;
                 baseName = GetResourceManager(parentObject)?.BaseName ?? string.Empty;
             }
 


### PR DESCRIPTION
All XAML bindings to resources are now localized. Still need to set `CurrentThread.CurrentUICulture` in the view locator to make the league overlay models work. Haven't figured out a good solution for those yet.