### PR TITLE
Make overlay open at mouse cursor position

### DIFF
--- a/src/Sidekick.Core/Natives/INativeProcess.cs
+++ b/src/Sidekick.Core/Natives/INativeProcess.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +11,8 @@ namespace Sidekick.Core.Natives
         bool IsSidekickInFocus { get; }
         Task CheckPermission();
         float ActiveWindowDpi { get; }
+        Rectangle GetScreenDimensions();
+        Point GetCursorPosition();
         string ClientLogPath { get; }
     }
 }

--- a/src/Sidekick/Natives/NativeProcess.cs
+++ b/src/Sidekick/Natives/NativeProcess.cs
@@ -29,11 +29,21 @@ namespace Sidekick.Natives
         [DllImport("user32.dll")]
         private static extern bool GetWindowRect(IntPtr hWnd, out Rectangle lpRect);
 
+        [DllImport("user32.dll")]
+        static extern bool ClientToScreen(IntPtr hWnd, ref Point lpPoint);
+
         [DllImport("advapi32.dll", SetLastError = true)]
         private static extern bool OpenProcessToken(IntPtr ProcessHandle, uint DesiredAccess, out IntPtr TokenHandle);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         private static extern bool CloseHandle(IntPtr hObject);
+
+        /// <summary>
+        /// Retrieves the cursor's position, in screen coordinates.
+        /// </summary>
+        /// <see>See MSDN documentation for further information.</see>
+        [DllImport("user32.dll")]
+        private static extern bool GetCursorPos(out Point lpPoint);
         #endregion
 
         private const string PATH_OF_EXILE_PROCESS_TITLE = "Path of Exile";
@@ -128,6 +138,18 @@ namespace Sidekick.Natives
         {
             GetWindowRect(GetForegroundWindow(), out var windowRect);
             return windowRect.Width;
+        }
+
+        public Rectangle GetScreenDimensions()
+        {
+            return GetWindowRect(GetForegroundWindow(), out var rectangle) ? rectangle : default;
+        }
+
+        public Point GetCursorPosition()
+        {
+            GetCursorPos(out var lpPoint);
+
+            return lpPoint;
         }
 
         public async Task CheckPermission()

--- a/src/Sidekick/Windows/PriceCheck/OverlayController.cs
+++ b/src/Sidekick/Windows/PriceCheck/OverlayController.cs
@@ -14,7 +14,6 @@ using Sidekick.Core.Loggers;
 using Sidekick.Core.Natives;
 using Sidekick.Core.Settings;
 using Application = System.Windows.Application;
-using Cursor = System.Windows.Forms.Cursor;
 
 namespace Sidekick.Windows.PriceCheck
 {
@@ -84,8 +83,9 @@ namespace Sidekick.Windows.PriceCheck
         public void Open()
         {
             var scale = 96f / nativeProcess.ActiveWindowDpi;
-            var xScaled = (int)(Cursor.Position.X * scale);
-            var yScaled = (int)(Cursor.Position.Y * scale);
+            var cursorPosition = nativeProcess.GetCursorPosition();
+            var xScaled = (int)(cursorPosition.X * scale);
+            var yScaled = (int)(cursorPosition.Y * scale);
 
             EnsureBounds(xScaled, yScaled, scale);
             Show();
@@ -107,14 +107,15 @@ namespace Sidekick.Windows.PriceCheck
         /// </summary>
         private void EnsureBounds(int desiredX, int desiredY, float scale)
         {
-            // var screenRect = Screen.FromPoint(Cursor.Position).Bounds;
-            // var xMidScaled = (screenRect.X + (screenRect.Width / 2)) * scale;
-            // var yMidScaled = (screenRect.Y + (screenRect.Height / 2)) * scale;
-            // 
-            // var positionX = desiredX + (desiredX < xMidScaled ? WINDOW_PADDING : -WINDOW_WIDTH - WINDOW_PADDING);
-            // var positionY = desiredY + (desiredY < yMidScaled ? WINDOW_PADDING : -WINDOW_HEIGHT - WINDOW_PADDING);
-            // 
-            // overlayWindow.SetWindowPosition(positionX, positionY);
+            var screenRect = nativeProcess.GetScreenDimensions();
+
+            var xMidScaled = (screenRect.X + (screenRect.Width / 2)) * scale;
+            var yMidScaled = (screenRect.Y + (screenRect.Height / 2)) * scale;
+
+            var positionX = desiredX + (desiredX < xMidScaled ? overlayWindow.Padding.Left : -overlayWindow.Width - overlayWindow.Padding.Left);
+            var positionY = desiredY + (desiredY < yMidScaled ? overlayWindow.Padding.Top : -overlayWindow.Height- overlayWindow.Padding.Top);
+
+            overlayWindow.SetWindowPosition((int)positionX, (int)positionY);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #222 

No reliance on Windows.Forms in the OverlayController anymore. Tested okay on my monitors but might very well still need some tweaking. 