### PR TITLE
Fix rare crash when dragging windows

### DIFF
--- a/src/Sidekick/Windows/BaseWindow.cs
+++ b/src/Sidekick/Windows/BaseWindow.cs
@@ -38,7 +38,11 @@ namespace Sidekick.Windows
 
         private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            DragMove();
+            try
+            {
+                DragMove();
+            }
+            catch (InvalidOperationException) { }
         }
 
         public new void Show()

--- a/src/Sidekick/Windows/Prices/PriceView.xaml.cs
+++ b/src/Sidekick/Windows/Prices/PriceView.xaml.cs
@@ -5,15 +5,13 @@ using System.Windows.Controls;
 using System.Windows.Navigation;
 using Sidekick.Core.Natives;
 using Sidekick.UI.Prices;
-using Sidekick.UI.Views;
 
 namespace Sidekick.Windows.Prices
 {
-    public partial class PriceView : BaseWindow, ISidekickView
+    public partial class PriceView : BaseWindow
     {
         private readonly IPriceViewModel viewModel;
         private readonly INativeBrowser nativeBrowser;
-        private readonly INativeCursor cursor;
 
         public PriceView(
             IServiceProvider serviceProvider,
@@ -24,7 +22,6 @@ namespace Sidekick.Windows.Prices
         {
             this.viewModel = viewModel;
             this.nativeBrowser = nativeBrowser;
-            this.cursor = cursor;
             InitializeComponent();
             DataContext = viewModel;
 
@@ -63,7 +60,6 @@ namespace Sidekick.Windows.Prices
                 if ((scrollViewer.VerticalOffset / scrollViewer.ScrollableHeight) > 0.8d)
                 {
                     viewModel.LoadMoreData();
-                    return;
                 }
             }
         }
@@ -80,6 +76,5 @@ namespace Sidekick.Windows.Prices
             nativeBrowser.Open(e.Uri);
             e.Handled = true;
         }
-
     }
 }

--- a/src/Sidekick/Windows/Settings/SettingsView.xaml.cs
+++ b/src/Sidekick/Windows/Settings/SettingsView.xaml.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Windows;
-using System.Windows.Input;
 using Sidekick.UI.Settings;
-using Sidekick.UI.Views;
 
 namespace Sidekick.Windows.Settings
 {
-    public partial class SettingsView : BaseWindow, ISidekickView
+    public partial class SettingsView : BaseWindow
     {
         private readonly ISettingsViewModel viewModel;
 
@@ -21,11 +19,6 @@ namespace Sidekick.Windows.Settings
             DataContext = viewModel;
 
             Show();
-        }
-
-        private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
-        {
-            DragMove();
         }
 
         private void SaveChanges_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
When dragging a window, especially when Visual Studio is attached and debugging on a slowish laptop, you can get an `InvalidOperationException` thrown from `DragMove()` that says you are not allowed to move when the primary mouse button isn't held down.

Wrapping it in a try-catch simply ignores this error to prevent a crash, as it only happens if a move is "queued" up after the mouse has been released.