### PR TITLE
Setting up the foundations for unit tests

### DIFF
--- a/Sidekick.Business.Tests/ItemParserTests/ExampleItems.cs
+++ b/Sidekick.Business.Tests/ItemParserTests/ExampleItems.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sidekick.Business.Tests.ItemParserTests
+{
+    public static class ExampleItems
+    {
+        public const string NormalMap = @"Rarity: Normal
+Beach Map
+--------
+Map Tier: 1
+Atlas Region: Glennach Cairns
+--------
+Item Level: 52
+--------
+Travel to this Map by using it in a personal Map Device.Maps can only be used once.
+";
+
+        public const string MagicMap = @"Rarity: Magic
+Mirrored Beach Map
+--------
+Map Tier: 1
+Atlas Region: Glennach Cairns
+Item Quantity: +10% (augmented)
+Item Rarity: +6% (augmented)
+Monster Pack Size: +4% (augmented)
+--------
+Item Level: 52
+--------
+Monsters reflect 13% of Elemental Damage
+--------
+Travel to this Map by using it in a personal Map Device. Maps can only be used once.
+";
+
+        public const string UniqueMap = @"Rarity: Unique
+Maelström of Chaos
+Atoll Map
+--------
+Map Tier: 5
+Atlas Region: Tirn's End
+Item Quantity: +69% (augmented)
+Item Rarity: +356% (augmented)
+Quality: +10% (augmented)
+--------
+Item Level: 76
+--------
+Area has patches of chilled ground
+Monsters deal 50% extra Damage as Lightning
+Monsters are Immune to randomly chosen Elemental Ailments or Stun
+Monsters' Melee Attacks apply random Curses on Hit
+Monsters reflect Curses
+--------
+Whispers from a world apart
+Speak my name beyond the tomb;
+Bound within the Maelström's heart,
+Will they grant me strength or doom?
+--------
+Travel to this Map by using it in a personal Map Device.Maps can only be used once.
+";
+
+
+        public const string UniqueSixLink = @"Rarity: Unique
+Carcass Jack
+Varnished Coat
+--------
+Quality: +20% (augmented)
+Evasion Rating: 960 (augmented)
+Energy Shield: 186 (augmented)
+--------
+Requirements:
+Level: 70
+Str: 68
+Dex: 96
+Int: 111
+--------
+Sockets: B-B-R-B-B-B 
+--------
+Item Level: 81
+--------
+128% increased Evasion and Energy Shield
++55 to maximum Life
++12% to all Elemental Resistances
+44% increased Area of Effect
+47% increased Area Damage
+Extra gore
+--------
+""...The discomfort shown by the others is amusing, but none
+can deny that my work has made quite the splash...""
+- Maligaro's Journal
+";
+
+        public const string UnidentifiedUnique = @"Rarity: Unique
+Jade Hatchet
+--------
+One Handed Axe
+Physical Damage: 10-15
+Critical Strike Chance: 5.00%
+Attacks per Second: 1.45
+Weapon Range: 11
+--------
+Requirements:
+Str: 21
+--------
+Sockets: R-G-B 
+--------
+Item Level: 71
+--------
+Unidentified
+;";
+    }
+}

--- a/Sidekick.Business.Tests/ItemParserTests/ParseEquipment.cs
+++ b/Sidekick.Business.Tests/ItemParserTests/ParseEquipment.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using Sidekick.Business.Parsers;
+using Sidekick.Business.Parsers.Models;
+
+namespace Sidekick.Business.Tests.ItemParserTests
+{
+    public class ParseEquipment : TestContext<ItemParser>
+    {
+        [Test]
+        public async Task ParseUnidentifiedUnique()
+        {
+            var actual = await Subject.ParseItem(ExampleItems.UnidentifiedUnique) as EquippableItem;
+
+            using (new AssertionScope())
+            {
+                actual.Name.Should().Be("Jade Hatchet");
+                actual.Type.Should().Be("Jade Hatchet");
+                actual.IsIdentified.Should().BeFalse();
+            }
+        }
+
+        [Test]
+        public async Task ParseSixLinkUnique()
+        {
+            var actual = await Subject.ParseItem(ExampleItems.UniqueSixLink) as EquippableItem;
+
+            using (new AssertionScope())
+            {
+                actual.Name.Should().Be("Carcass Jack");
+                actual.Type.Should().Be("Varnished Coat");
+                actual.Links.Min.Should().Be(6);
+            }
+        }
+    }
+}

--- a/Sidekick.Business.Tests/ItemParserTests/ParseMaps.cs
+++ b/Sidekick.Business.Tests/ItemParserTests/ParseMaps.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using Sidekick.Business.Maps;
+using FluentAssertions;
+using Sidekick.Business.Parsers.Models;
+using Sidekick.Business.Parsers;
+using System.Threading.Tasks;
+using FluentAssertions.Execution;
+
+namespace Sidekick.Business.Tests.ItemParserTests
+{
+    public class ParseMaps : TestContext<ItemParser>
+    {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            GetMockFor<IMapService>()
+                .Setup(o => o.MapNames)
+                .Returns(new HashSet<string> { "Beach" });
+        }
+
+        [Test]
+        public async Task ParseNormalMap()
+        {
+            var actual = await Subject.ParseItem(ExampleItems.NormalMap) as MapItem;
+
+            using (new AssertionScope())
+            {
+                actual.Name.Should().Be("Beach Map");
+                actual.MapTier.Should().Be("1");
+            }
+        }
+
+        [Test]
+        public async Task ParseMagicMap()
+        {
+            var actual = await Subject.ParseItem(ExampleItems.MagicMap) as MapItem;
+
+            using(new AssertionScope())
+            {
+                // Probably incorrect behavior, right now it always appends blighted prefix for magic maps
+                actual.Name.Should().Be("Blighted Beach");
+                actual.Type.Should().Be("Beach");
+                actual.MapTier.Should().Be("1");
+            }
+        }
+
+        [Test]
+        public async Task ParseUniqueMap()
+        {
+            var actual = await Subject.ParseItem(ExampleItems.UniqueMap) as MapItem;
+
+            using (new AssertionScope())
+            {
+                actual.Name.Should().Be("Maelström of Chaos");
+                actual.MapTier.Should().Be("5");
+                actual.ItemQuantity.Should().Be("69");
+                actual.ItemRarity.Should().Be("356");
+            }
+        }
+    }
+}

--- a/Sidekick.Business.Tests/Sidekick.Business.Tests.csproj
+++ b/Sidekick.Business.Tests/Sidekick.Business.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Sidekick.Business\Sidekick.Business.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sidekick.Business.Tests/SidekickFixture.cs
+++ b/Sidekick.Business.Tests/SidekickFixture.cs
@@ -1,0 +1,24 @@
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Microsoft.Extensions.Logging;
+using Sidekick.Business.Languages;
+using Sidekick.Business.Tokenizers;
+using Sidekick.Business.Tokenizers.ItemName;
+using Sidekick.Core.Settings;
+
+namespace Sidekick.Business.Tests
+{
+    public class SidekickFixture : Fixture
+    {
+        public SidekickFixture()
+        {
+            this.Customize(new AutoMoqCustomization());
+
+            this.Register<ITokenizer>(this.Create<ItemNameTokenizer>);
+            this.Register<ILanguageProvider>(this.Create<LanguageProvider>);
+            this.Register(DefaultSettings.CreateDefault);
+
+            this.Freeze<ILogger>();
+        }
+    }
+}

--- a/Sidekick.Business.Tests/SidekickFixture.cs
+++ b/Sidekick.Business.Tests/SidekickFixture.cs
@@ -17,8 +17,6 @@ namespace Sidekick.Business.Tests
             this.Register<ITokenizer>(this.Create<ItemNameTokenizer>);
             this.Register<ILanguageProvider>(this.Create<LanguageProvider>);
             this.Register(DefaultSettings.CreateDefault);
-
-            this.Freeze<ILogger>();
         }
     }
 }

--- a/Sidekick.Business.Tests/TestContext.cs
+++ b/Sidekick.Business.Tests/TestContext.cs
@@ -1,0 +1,22 @@
+using AutoFixture;
+using Moq;
+
+namespace Sidekick.Business.Tests
+{
+    public abstract class TestContext<T>
+    {
+        public SidekickFixture Fixture { get; set; }
+
+        public T Subject => Fixture.Freeze<T>();
+
+        public Mock<TMock> GetMockFor<TMock>() where TMock : class
+        {
+            return Fixture.Freeze<Mock<TMock>>();
+        }
+
+        public TestContext()
+        {
+            Fixture = new SidekickFixture();
+        }
+    }
+}

--- a/Sidekick.sln
+++ b/Sidekick.sln
@@ -21,7 +21,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sidekick", "src\Sidekick\Si
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sidekick.UI", "src\Sidekick.UI\Sidekick.UI.csproj", "{F8DCDD39-7D3D-4610-A677-062410F89779}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sidekick.Localization", "src\Sidekick.Localization\Sidekick.Localization.csproj", "{C7A61A43-9474-415E-84AD-381E45003C6F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sidekick.Localization", "src\Sidekick.Localization\Sidekick.Localization.csproj", "{C7A61A43-9474-415E-84AD-381E45003C6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sidekick.Business.Tests", "Sidekick.Business.Tests\Sidekick.Business.Tests.csproj", "{B7235282-296F-473E-80BC-47D620D80CA0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{B4E782B6-CF03-4448-81D1-3E308D20BF2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,9 +53,16 @@ Global
 		{C7A61A43-9474-415E-84AD-381E45003C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7A61A43-9474-415E-84AD-381E45003C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7A61A43-9474-415E-84AD-381E45003C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7235282-296F-473E-80BC-47D620D80CA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7235282-296F-473E-80BC-47D620D80CA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7235282-296F-473E-80BC-47D620D80CA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7235282-296F-473E-80BC-47D620D80CA0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B7235282-296F-473E-80BC-47D620D80CA0} = {B4E782B6-CF03-4448-81D1-3E308D20BF2B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17B5631D-95B3-4007-BE6B-C9BBE799D014}

--- a/src/Sidekick.Core/Settings/DefaultSettings.cs
+++ b/src/Sidekick.Core/Settings/DefaultSettings.cs
@@ -1,6 +1,6 @@
 namespace Sidekick.Core.Settings
 {
-    internal static class DefaultSettings
+    public static class DefaultSettings
     {
         public static SidekickSettings CreateDefault()
         {


### PR DESCRIPTION
With lots of changes and new features being added to the ItemParser soon, I figured that getting started with some unit tests would be a good idea. With this infrastructure in place, it will hopefully be straightforward for people to add more tests in the future.

I've used NUnit, AutoFixture/AutoMoq and FluentAssertions because that's what I'm familiar with but that can be changed if there are other preferences.