### PR TITLE
#268 Fixed the setting for closing the windows by clicking outside

### DIFF
--- a/src/Sidekick.Core/Natives/IKeybindEvents.cs
+++ b/src/Sidekick.Core/Natives/IKeybindEvents.cs
@@ -19,6 +19,5 @@ namespace Sidekick.Core.Natives
         event Func<Task<bool>> OnTabRight;
         event Func<Task<bool>> OnOpenLeagueOverview;
         event Func<Task<bool>> OnWhisperReply;
-        event Func<int, int, Task> OnMouseClick;
     }
 }

--- a/src/Sidekick/Natives/KeybindEvents.cs
+++ b/src/Sidekick/Natives/KeybindEvents.cs
@@ -44,7 +44,6 @@ namespace Sidekick.Natives
         public event Func<Task<bool>> OnTabRight;
         public event Func<Task<bool>> OnOpenLeagueOverview;
         public event Func<Task<bool>> OnWhisperReply;
-        public event Func<int, int, Task> OnMouseClick;
 
         private IKeyboardMouseEvents hook = null;
         private bool isDisposed;
@@ -54,51 +53,34 @@ namespace Sidekick.Natives
             nativeKeyboard.OnKeyDown += NativeKeyboard_OnKeyDown;
             hook = Hook.GlobalEvents();
 
-#if !DEBUG
             hook.MouseWheelExt += Hook_MouseWheelExt;
-            hook.MouseUp += Hook_MouseUp;
-#endif
 
             Enabled = true;
 
             return Task.CompletedTask;
         }
 
-        private void Hook_MouseUp(object sender, MouseEventArgs e)
-        {
-            Task.Run(async () =>
-            {
-                if (!Enabled || !configuration.CloseOverlayWithMouse)
-                {
-                    return;
-                }
-
-                if (OnMouseClick != null) await OnMouseClick.Invoke(e.X, e.Y);
-            });
-        }
-
         private void Hook_MouseWheelExt(object sender, MouseEventExtArgs e)
         {
-            Task.Run(() =>
+            if (!configuration.EnableCtrlScroll || !nativeProcess.IsPathOfExileInFocus)
             {
-                if (!configuration.EnableCtrlScroll || !nativeProcess.IsPathOfExileInFocus)
+                return;
+            }
+
+            // Ctrl + Scroll wheel to move between stash tabs.
+            if (nativeKeyboard.IsKeyPressed("Ctrl"))
+            {
+                if (e.Delta > 0)
                 {
-                    return;
+                    stashService.ScrollLeft();
+                }
+                else
+                {
+                    stashService.ScrollRight();
                 }
 
-                // Ctrl + Scroll wheel to move between stash tabs.
-                if (nativeKeyboard.IsKeyPressed("Ctrl"))
-                {
-                    if (e.Delta > 0)
-                    {
-                        stashService.ScrollLeft();
-                    }
-                    else
-                    {
-                        stashService.ScrollRight();
-                    }
-                }
-            });
+                e.Handled = true;
+            }
         }
 
         private bool NativeKeyboard_OnKeyDown(string input)

--- a/src/Sidekick/Windows/Leagues/LeagueView.xaml.cs
+++ b/src/Sidekick/Windows/Leagues/LeagueView.xaml.cs
@@ -12,7 +12,8 @@ namespace Sidekick.Windows.Leagues
     public partial class LeagueView : BaseWindow
     {
         public LeagueView(ILeagueViewModel leagueViewModel, IServiceProvider serviceProvider)
-            : base(serviceProvider)
+            : base(serviceProvider,
+                  closeOnBlur: true)
         {
             InitializeComponent();
             ViewModel = leagueViewModel;
@@ -20,6 +21,7 @@ namespace Sidekick.Windows.Leagues
 
             SetWindowPositionPercent(25, 0);
             Show();
+            Activate();
         }
 
         public ILeagueViewModel ViewModel { get; set; }

--- a/src/Sidekick/Windows/Prices/PriceView.xaml.cs
+++ b/src/Sidekick/Windows/Prices/PriceView.xaml.cs
@@ -18,7 +18,8 @@ namespace Sidekick.Windows.Prices
             IPriceViewModel viewModel,
             INativeBrowser nativeBrowser,
             INativeCursor cursor)
-            : base(serviceProvider)
+            : base(serviceProvider,
+                  closeOnBlur: true)
         {
             this.viewModel = viewModel;
             this.nativeBrowser = nativeBrowser;
@@ -28,6 +29,7 @@ namespace Sidekick.Windows.Prices
             Loaded += OverlayWindow_Loaded;
 
             Show();
+            Activate();
 
             var position = cursor.GetCursorPosition();
             SetWindowPositionFromBottomRight(position.X - 10, position.Y - 10);


### PR DESCRIPTION
Also fixed the Ctrl+Scroll issue. I have had no issue removing the Task.Run inside the Scroll event. @domialex Can you make sure it works for you too? Maybe it got fixed with the .Net Core update (0.5.0)

References #268