### PR TITLE
Add multiple language support for poe.ninja

### DIFF
--- a/src/Sidekick.Business/Apis/Poe/Trade/Data/Leagues/ILeagueDataService.cs
+++ b/src/Sidekick.Business/Apis/Poe/Trade/Data/Leagues/ILeagueDataService.cs
@@ -6,7 +6,8 @@ namespace Sidekick.Business.Apis.Poe.Trade.Leagues
     public interface ILeagueDataService
     {
         List<League> Leagues { get; }
-
+        void LeagueChanged();
+        event Action OnLeagueChange;
         event Action OnNewLeagues;
     }
 }

--- a/src/Sidekick.Business/Apis/Poe/Trade/Data/Leagues/LeagueDataService.cs
+++ b/src/Sidekick.Business/Apis/Poe/Trade/Data/Leagues/LeagueDataService.cs
@@ -24,7 +24,10 @@ namespace Sidekick.Business.Apis.Poe.Trade.Leagues
             this.settings = settings;
         }
 
+        public event Action OnLeagueChange;
         public event Action OnNewLeagues;
+
+        public void LeagueChanged() => OnLeagueChange.Invoke();
 
         public async Task OnInit()
         {

--- a/src/Sidekick.Business/Apis/Poe/Trade/Search/TradeSearchService.cs
+++ b/src/Sidekick.Business/Apis/Poe/Trade/Search/TradeSearchService.cs
@@ -151,7 +151,7 @@ namespace Sidekick.Business.Apis.Poe.Trade.Search
                     };
                 }
 
-                var uri = $"{languageProvider.Language.PoeTradeApiBaseUrl}search/{configuration.LeagueId}";
+                var uri = new Uri($"{languageProvider.Language.PoeTradeApiBaseUrl}search/{configuration.LeagueId}");
                 var json = JsonSerializer.Serialize(request, poeTradeClient.Options);
                 var body = new StringContent(json, Encoding.UTF8, "application/json");
                 var response = await httpClientProvider.HttpClient.PostAsync(uri, body);

--- a/src/Sidekick.Business/Apis/PoeNinja/IPoeNinjaClient.cs
+++ b/src/Sidekick.Business/Apis/PoeNinja/IPoeNinjaClient.cs
@@ -5,6 +5,7 @@ namespace Sidekick.Business.Apis.PoeNinja
 {
     public interface IPoeNinjaClient
     {
+        public bool IsSupportingCurrentLanguage { get; }
         Task<PoeNinjaQueryResult<PoeNinjaItem>> QueryItem(string leagueId, ItemType itemType);
 
         Task<PoeNinjaQueryResult<PoeNinjaCurrency>> QueryItem(string leagueId, CurrencyType currency);

--- a/src/Sidekick.Business/Apis/PoeNinja/Models/PoeNinjaQueryResult.cs
+++ b/src/Sidekick.Business/Apis/PoeNinja/Models/PoeNinjaQueryResult.cs
@@ -1,13 +1,10 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Sidekick.Business.Apis.PoeNinja.Models
 {
     public class PoeNinjaQueryResult<T> where T : PoeNinjaResult
     {
         public List<T> Lines { get; set; }
+        public PoeNinjaQueryResultLanguage Language { get; set; }
     }
 }

--- a/src/Sidekick.Business/Apis/PoeNinja/Models/PoeNinjaQueryResultLanguage.cs
+++ b/src/Sidekick.Business/Apis/PoeNinja/Models/PoeNinjaQueryResultLanguage.cs
@@ -2,10 +2,12 @@ using System.Collections.Generic;
 
 namespace Sidekick.Business.Apis.PoeNinja.Models
 {
-    public class PoeNinjaCacheItem<T> where T : PoeNinjaResult
+    public class PoeNinjaQueryResultLanguage
     {
-        public string Type { get; set; }
-        public List<T> Items { get; set; }
+        /// <summary>
+        /// Language code.
+        /// </summary>
+        public string Name { get; set; }
         public Dictionary<string, string> Translations { get; set; }
     }
 }

--- a/src/Sidekick.Business/Apis/PoeNinja/PoeNinjaClient.cs
+++ b/src/Sidekick.Business/Apis/PoeNinja/PoeNinjaClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -6,23 +7,44 @@ using System.Threading.Tasks;
 using Serilog;
 using Sidekick.Business.Apis.PoeNinja.Models;
 using Sidekick.Business.Http;
+using Sidekick.Business.Languages;
+using Sidekick.Core.Initialization;
 
 namespace Sidekick.Business.Apis.PoeNinja
 {
     /// <summary>
     /// https://poe.ninja/swagger
     /// </summary>
-    public class PoeNinjaClient : IPoeNinjaClient
+    public class PoeNinjaClient : IPoeNinjaClient, IOnAfterInit
     {
         private readonly static Uri POE_NINJA_API_BASE_URL = new Uri("https://poe.ninja/api/data/");
+        /// <summary>
+        /// Poe.ninja uses its own language codes.
+        /// </summary>
+        private readonly static Dictionary<string, string> POE_NINJA_LANGUAGE_CODES = new Dictionary<string, string>()
+        {
+             { "de", "ge" }, // German.
+             { "en", "en" }, // English.
+             { "es", "es" }, // Spanish.
+             { "fr", "fr" }, // French.
+             { "kr", "ko" }, // Korean.
+             { "pt", "en" }, // Portuguese.
+             { "ru", "ru" }, // Russian.
+             { "th", "th" }, // Thai.
+        };
+        private string languageCode;
         private readonly HttpClient httpClient;
         private readonly ILogger logger;
+        private readonly ILanguageProvider languageProvider;
         private JsonSerializerOptions _jsonSerializerOptions;
+        public bool IsSupportingCurrentLanguage { get; private set; }
 
-        public PoeNinjaClient(IHttpClientProvider httpClientProvider, ILogger logger)
+        public PoeNinjaClient(IHttpClientProvider httpClientProvider,
+                              ILanguageProvider languageProvider,
+                              ILogger logger)
         {
             httpClient = httpClientProvider.HttpClient;
-
+            this.languageProvider = languageProvider;
             this.logger = logger.ForContext(GetType());
 
             var jsonSerializerOptions = new JsonSerializerOptions()
@@ -36,7 +58,7 @@ namespace Sidekick.Business.Apis.PoeNinja
 
         public async Task<PoeNinjaQueryResult<PoeNinjaItem>> QueryItem(string leagueId, ItemType itemType)
         {
-            var url = $"{POE_NINJA_API_BASE_URL}itemoverview?league={leagueId}&type={itemType}";
+            var url = new Uri($"{POE_NINJA_API_BASE_URL}itemoverview?league={leagueId}&type={itemType}&language={languageCode}");
 
             try
             {
@@ -49,12 +71,12 @@ namespace Sidekick.Business.Apis.PoeNinja
                 logger.Information("Could not fetch {itemType} from poe.ninja", itemType);
             }
 
-            return new PoeNinjaQueryResult<PoeNinjaItem>() { Lines = new System.Collections.Generic.List<PoeNinjaItem>() };
+            return new PoeNinjaQueryResult<PoeNinjaItem>() { Lines = new List<PoeNinjaItem>() };
         }
 
         public async Task<PoeNinjaQueryResult<PoeNinjaCurrency>> QueryItem(string leagueId, CurrencyType currency)
         {
-            var url = $"{POE_NINJA_API_BASE_URL}currencyoverview?league={leagueId}&type={currency}";
+            var url = new Uri($"{POE_NINJA_API_BASE_URL}currencyoverview?league={leagueId}&type={currency}&language={languageCode}");
 
             try
             {
@@ -67,7 +89,14 @@ namespace Sidekick.Business.Apis.PoeNinja
                 logger.Information("Could not fetch {currency} from poe.ninja", currency);
             }
 
-            return new PoeNinjaQueryResult<PoeNinjaCurrency>() { Lines = new System.Collections.Generic.List<PoeNinjaCurrency>() };
+            return new PoeNinjaQueryResult<PoeNinjaCurrency>() { Lines = new List<PoeNinjaCurrency>() };
+        }
+
+        public Task OnAfterInit()
+        {
+            IsSupportingCurrentLanguage = POE_NINJA_LANGUAGE_CODES.TryGetValue(languageProvider.Current.LanguageCode, out languageCode);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Sidekick.Business/Apis/PoeNinja/PoeNinjaClient.cs
+++ b/src/Sidekick.Business/Apis/PoeNinja/PoeNinjaClient.cs
@@ -28,7 +28,7 @@ namespace Sidekick.Business.Apis.PoeNinja
              { "es", "es" }, // Spanish.
              { "fr", "fr" }, // French.
              { "kr", "ko" }, // Korean.
-             { "pt", "en" }, // Portuguese.
+             { "pt", "pt" }, // Portuguese.
              { "ru", "ru" }, // Russian.
              { "th", "th" }, // Thai.
         };

--- a/src/Sidekick.Business/Languages/Implementations/LanguageDE.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageDE.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("German", "Seltenheit")]
+    [Language("German", "Seltenheit", "de")]
     public class LanguageDE : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://de.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageEN.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageEN.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("English", "Rarity")]
+    [Language("English", "Rarity", "en")]
     public class LanguageEN : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://www.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageES.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageES.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("Spanish", "Rareza")]
+    [Language("Spanish", "Rareza", "es")]
     public class LanguageES : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://es.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageFR.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageFR.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("French", "Rareté")]
+    [Language("French", "Rareté", "fr")]
     public class LanguageFR : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://fr.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageKR.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageKR.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("Korean", "아이템 희귀도")]
+    [Language("Korean", "아이템 희귀도", "kr")]
     public class LanguageKR : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://poe.game.daum.net/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguagePT.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguagePT.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("Portuguese", "Raridade")]
+    [Language("Portuguese", "Raridade", "pt")]
     public class LanguagePT : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://br.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageRU.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageRU.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("Russian", "Редкость")]
+    [Language("Russian", "Редкость", "ru")]
     public class LanguageRU : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://ru.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageTH.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageTH.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("Thai", "ความหายาก")]
+    [Language("Thai", "ความหายาก", "th")]
     public class LanguageTH : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("https://th.pathofexile.com/trade/search/");

--- a/src/Sidekick.Business/Languages/Implementations/LanguageZHTW.cs
+++ b/src/Sidekick.Business/Languages/Implementations/LanguageZHTW.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Sidekick.Business.Languages.Implementations
 {
-    [Language("TraditionalChinese", "稀有度")]
+    [Language("TraditionalChinese", "稀有度", "zh")]
     public class LanguageZHTW : ILanguage
     {
         public Uri PoeTradeSearchBaseUrl => new Uri("http://web.poe.garena.tw/trade/search/");

--- a/src/Sidekick.Business/Languages/LanguageAttribute.cs
+++ b/src/Sidekick.Business/Languages/LanguageAttribute.cs
@@ -4,14 +4,16 @@ namespace Sidekick.Business.Languages
 {
     public class LanguageAttribute : Attribute
     {
-        public LanguageAttribute(string name, string rarityDescription)
+        public LanguageAttribute(string name, string descriptionRarity, string languageCode)
         {
             Name = name;
-            DescriptionRarity = rarityDescription;
+            DescriptionRarity = descriptionRarity;
+            LanguageCode = languageCode;
         }
 
         public string Name { get; private set; }
         public string DescriptionRarity { get; private set; }
+        public string LanguageCode { get; private set; }
         public Type ImplementationType { get; set; }
     }
 }

--- a/src/Sidekick.Business/StartupExtensions.cs
+++ b/src/Sidekick.Business/StartupExtensions.cs
@@ -33,8 +33,7 @@ namespace Sidekick.Business
             services.AddSingleton<IChatService, ChatService>();
             services.AddSingleton<IHttpClientProvider, HttpClientProvider>();
             services.AddSingleton<ILanguageProvider, LanguageProvider>();
-            services.AddSingleton<IPartyService, PartyService>();
-            services.AddSingleton<IPoeNinjaClient, PoeNinjaClient>();
+            services.AddSingleton<IPartyService, PartyService>();            
             services.AddSingleton<IPoePriceInfoClient, PoePriceInfoClient>();
             services.AddSingleton<IStashService, StashService>();
             services.AddSingleton<ITradeSearchService, TradeSearchService>();
@@ -49,6 +48,7 @@ namespace Sidekick.Business
             services.AddInitializableService<IItemDataService, ItemDataService>();
             services.AddInitializableService<ILeagueDataService, LeagueDataService>();
             services.AddInitializableService<IParserService, ParserService>();
+            services.AddInitializableService<IPoeNinjaClient, PoeNinjaClient>();
             services.AddInitializableService<IPoeNinjaCache, PoeNinjaCache>();
             services.AddInitializableService<IPseudoStatDataService, PseudoStatDataService>();
             services.AddInitializableService<IParserPatterns, ParserPatterns>();


### PR DESCRIPTION
- Add language codes to the language objects.
- Fix some strings that were used as URIs.
- Make PoeNinjaClient and PoeNinjaCache refresh when changing league and language.
- Fix PoeNinjaCache returning some items with higher chaos values. (legacy items?)
- Closes #217.