### PR TITLE
Fix searching for uniques with multiple base types

### DIFF
--- a/src/Sidekick.Business/Apis/Poe/Trade/Data/Items/ItemDataService.cs
+++ b/src/Sidekick.Business/Apis/Poe/Trade/Data/Items/ItemDataService.cs
@@ -137,6 +137,7 @@ namespace Sidekick.Business.Apis.Poe.Trade.Data.Items
             return results
                 .OrderBy(x => x.Rarity == Rarity.Unique ? 0 : 1)
                 .ThenBy(x => x.Rarity == Rarity.Unknown ? 0 : 1)
+                .ThenBy(x => x.Type == itemSections.HeaderSection.Last() ? 0 : 1)
                 .FirstOrDefault();
         }
 


### PR DESCRIPTION
Sort the results by their type before returning it.
This should ensure that always the correct base is returned.

Fixes: #450 