### PR TITLE
Fix parsing of some items which require prefixes to be kept

### DIFF
--- a/src/Sidekick.Business/Apis/Poe/Trade/Data/Items/ItemDataService.cs
+++ b/src/Sidekick.Business/Apis/Poe/Trade/Data/Items/ItemDataService.cs
@@ -114,7 +114,12 @@ namespace Sidekick.Business.Apis.Poe.Trade.Data.Items
             var results = new List<ItemData>();
 
             // Rares may have conflicting names, so we don't want to search any unique items that may have that name. Like "Ancient Orb" which can be used by abyss jewels.
-            if (itemRarity != Rarity.Rare && nameAndTypeDictionary.TryGetValue(GetLineWithoutPrefixes(itemSections.HeaderSection[1]), out var itemData))
+            // there are some items which have prefixes which we don't wan to remove, like the "Blighted Delirium Orb"
+            if (itemRarity != Rarity.Rare && nameAndTypeDictionary.TryGetValue(itemSections.HeaderSection[1], out var itemData))
+            {
+                results.AddRange(itemData);
+            }
+            else if (itemRarity != Rarity.Rare && nameAndTypeDictionary.TryGetValue(GetLineWithoutPrefixes(itemSections.HeaderSection[1]), out itemData))
             {
                 results.AddRange(itemData);
             }

--- a/src/Sidekick.Business/Apis/Poe/Trade/Data/Stats/StatDataService.cs
+++ b/src/Sidekick.Business/Apis/Poe/Trade/Data/Stats/StatDataService.cs
@@ -180,17 +180,20 @@ namespace Sidekick.Business.Apis.Poe.Trade.Data.Stats
         }
 
         private readonly Regex ParseHashPattern = new Regex("\\#");
+
         private void FillMods(List<Modifier> mods, List<StatData> patterns, string text)
         {
             var unorderedMods = new List<Modifier>();
 
             foreach (var data in patterns
+                .AsParallel()
                 .Where(x => x.Pattern != null && x.Pattern.IsMatch(text)))
             {
                 FillMod(unorderedMods, text, data, data.Pattern.Match(text));
             }
 
             foreach (var data in patterns
+                .AsParallel()
                 .Where(x => x.NegativePattern != null && x.NegativePattern.IsMatch(text)))
             {
                 FillMod(unorderedMods, text, data, data.NegativePattern.Match(text), true);


### PR DESCRIPTION
On some items we don't want to remove prefixes, like the "Blighted Delirium Oorb".