### PR TITLE
Add title and icon to electron notifications

### DIFF
--- a/src/Sidekick.Application/Initialization/InitializeHandler.cs
+++ b/src/Sidekick.Application/Initialization/InitializeHandler.cs
@@ -167,10 +167,8 @@ namespace Sidekick.Application.Initialization
                 await Task.Delay(500);
 
                 // Show a system notification
-                await mediator.Send(new OpenNotificationCommand(string.Format(resources.Notification_Message, settings.Price_Key_Check.ToKeybindString(), settings.Price_Key_Close.ToKeybindString()), true)
-                {
-                    Title = resources.Notification_Title,
-                });
+                await mediator.Send(new OpenNotificationCommand(string.Format(resources.Notification_Message, settings.Price_Key_Check.ToKeybindString(), settings.Price_Key_Close.ToKeybindString()),
+                                                                resources.Notification_Title));
 
                 viewLocator.Close(View.Initialization);
 

--- a/src/Sidekick.Domain/Notifications/Commands/OpenNotificationCommand.cs
+++ b/src/Sidekick.Domain/Notifications/Commands/OpenNotificationCommand.cs
@@ -11,11 +11,11 @@ namespace Sidekick.Domain.Notifications.Commands
         /// Open a notification message
         /// </summary>
         /// <param name="message">The message to show in the notification</param>
-        /// <param name="isSystemNotification">If true, the notification will show as a system (Windows) tooltip; if false, as an application window.</param>
-        public OpenNotificationCommand(string message, bool isSystemNotification = false)
+        /// <param name="title">The title of the notification (optional)</param>
+        public OpenNotificationCommand(string message, string title = null)
         {
             Message = message;
-            IsSystemNotification = isSystemNotification;
+            Title = title;
         }
 
         /// <summary>
@@ -27,10 +27,5 @@ namespace Sidekick.Domain.Notifications.Commands
         /// The message to show in the notification
         /// </summary>
         public string Message { get; set; }
-
-        /// <summary>
-        /// If true, the notification will show as a system (Windows) tooltip; if false, as an application window.
-        /// </summary>
-        public bool IsSystemNotification { get; set; }
     }
 }

--- a/src/Sidekick.Presentation.Blazor.Electron/Notifications/OpenNotificationHandler.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Notifications/OpenNotificationHandler.cs
@@ -1,15 +1,28 @@
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
+using Microsoft.AspNetCore.Hosting;
 using Sidekick.Domain.Notifications.Commands;
 
 namespace Sidekick.Presentation.Blazor.Electron.Notifications
 {
     public class OpenNotificationHandler : ICommandHandler<OpenNotificationCommand>
     {
+        private IWebHostEnvironment WebHostEnvironment;
+
+        public OpenNotificationHandler(IWebHostEnvironment webHostEnvironment)
+        {
+            WebHostEnvironment = webHostEnvironment;
+        }
+
         public Task<Unit> Handle(OpenNotificationCommand request, CancellationToken cancellationToken)
         {
-            ElectronNET.API.Electron.Notification.Show(new ElectronNET.API.Entities.NotificationOptions(request.Title, request.Message));
+            var notificationOptions = new ElectronNET.API.Entities.NotificationOptions(request.Title, request.Message)
+            {
+                Icon = $"{WebHostEnvironment.ContentRootPath}Assets/ExaltedOrb.png"
+            };
+
+            ElectronNET.API.Electron.Notification.Show(notificationOptions);
             return Unit.Task;
         }
     }

--- a/src/Sidekick.Presentation.Blazor/Development/Tests.razor
+++ b/src/Sidekick.Presentation.Blazor/Development/Tests.razor
@@ -1,4 +1,5 @@
 @page "/development/tests"
+@using Sidekick.Domain.Notifications.Commands
 
 <DevelopmentLayout>
     <MudAppBar Color="Color.Primary">
@@ -7,16 +8,53 @@
 
     <MudMainContent>
         <MudContainer Class="py-6">
-            <MudButton Variant="Variant.Filled" OnClick="ThrowException">Throw an exception</MudButton>
+
+            <MudCard Class="mt-6">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">General</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    <MudButton Variant="Variant.Filled" OnClick="ThrowException">Throw an exception</MudButton>
+                </MudCardContent>
+            </MudCard>
+
+            <MudCard Class="mt-6">
+                <MudCardHeader>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Notification</MudText>
+                    </CardHeaderContent>
+                </MudCardHeader>
+                <MudCardContent>
+                    <MudText>OpenNotificationHandler must be implemented.</MudText>
+                    <MudTextField Label="Title" @bind-Value="NotificationTitle" />
+                    <MudTextField Label="Message" @bind-Value="NotificationMessage" />
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton Variant="Variant.Filled" OnClick="ShowNotification">Show notification</MudButton>
+                </MudCardActions>
+            </MudCard>
+
         </MudContainer>
     </MudMainContent>
 </DevelopmentLayout>
 
 @code {
+    [Inject] private IMediator Mediator { get; set; }
+
+    private string NotificationTitle { get; set; }
+    private string NotificationMessage { get; set; }
+
     public void ThrowException()
     {
 #pragma warning disable S112 // General exceptions should never be thrown
         throw new Exception("Developper test from the exception page.");
 #pragma warning restore S112 // General exceptions should never be thrown
+    }
+
+    public async void ShowNotification()
+    {
+        await Mediator.Send(new OpenNotificationCommand(NotificationMessage, NotificationTitle));
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4694217/108648660-d18dba00-7489-11eb-8432-685c4c89d517.png)

Still can't find a way to fix the executable/app name at the bottom.
When launched from the setup it shows `electron.app.Sidekick` at least.