### PR TITLE
Add a protection for CSRF

### DIFF
--- a/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtection.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtection.cs
@@ -8,8 +8,8 @@ namespace Sidekick.Presentation.Blazor.Electron.App
     /// </summary>
     public class ElectronCookieProtection
     {
-        public string Name { get; init; } = "ElectronCookieProtection";
-        public string Value { get; init; } = Guid.NewGuid().ToString();
+        public string Name { get; init; }
+        public string Value { get; init; }
         public CookieDetails Cookie { get; init; }
 
         public ElectronCookieProtection()

--- a/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtection.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtection.cs
@@ -1,0 +1,27 @@
+using System;
+using ElectronNET.API.Entities;
+
+namespace Sidekick.Presentation.Blazor.Electron.App
+{
+    /// <summary>
+    /// Service that holds the cookie name and value for <see cref="ElectronCookieProtectionMiddleware"/>.
+    /// </summary>
+    public class ElectronCookieProtection
+    {
+        public string Name { get; init; } = "ElectronCookieProtection";
+        public string Value { get; init; } = Guid.NewGuid().ToString();
+        public CookieDetails Cookie { get; init; }
+
+        public ElectronCookieProtection()
+        {
+            Name = "ElectronCookieProtection";
+            Value = Guid.NewGuid().ToString();
+            Cookie = new CookieDetails()
+            {
+                Name = Name,
+                Value = Value,
+                Url = "http://localhost",
+            };
+        }
+    }
+}

--- a/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtectionExtension.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtectionExtension.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Sidekick.Presentation.Blazor.Electron.App
+{
+    public static class ElectronCookieProtectionExtension
+    {
+        public static IApplicationBuilder AddElectronCookieProtection(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<ElectronCookieProtectionMiddleware>();
+        }
+    }
+}

--- a/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtectionMiddleware.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/App/ElectronCookieProtectionMiddleware.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Sidekick.Presentation.Blazor.Electron.App
+{
+    /// <summary>
+    /// Middleware that checks if the requests being made are from the Electron app and nothing else.
+    /// </summary>
+    public class ElectronCookieProtectionMiddleware
+    {
+        private RequestDelegate Next { get; init; }
+        private ElectronCookieProtection ElectronAuthorizationCookie { get; init; }
+
+        public ElectronCookieProtectionMiddleware(RequestDelegate next, ElectronCookieProtection electronAuthorizationCookie)
+        {
+            Next = next;
+            ElectronAuthorizationCookie = electronAuthorizationCookie;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            context.Request.Cookies.TryGetValue(ElectronAuthorizationCookie.Name, out string cookie);
+
+            if (cookie != ElectronAuthorizationCookie.Value)
+            {
+                context.Response.Clear();
+                context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                return;
+            }
+
+            await Next.Invoke(context);
+        }
+
+    }
+}

--- a/src/Sidekick.Presentation.Blazor.Electron/Startup.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using ElectronNET.API.Entities;
@@ -6,6 +7,7 @@ using FluentValidation.AspNetCore;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,6 +23,7 @@ using Sidekick.Mapper;
 using Sidekick.Mediator;
 using Sidekick.Persistence;
 using Sidekick.Platform;
+using Sidekick.Presentation.Blazor.Electron.App;
 using Sidekick.Presentation.Blazor.Electron.Keybinds;
 using Sidekick.Presentation.Blazor.Electron.Tray;
 using Sidekick.Presentation.Blazor.Electron.Views;
@@ -83,6 +86,7 @@ namespace Sidekick.Presentation.Blazor.Electron
             services.AddSingleton<TrayProvider>();
             services.AddSingleton<IViewLocator, ViewLocator>();
             services.AddSingleton<IKeybindProvider, KeybindProvider>();
+            services.AddSingleton<ElectronCookieProtection>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -110,6 +114,8 @@ namespace Sidekick.Presentation.Blazor.Electron
             app.UseStaticFiles();
 
             app.UseRouting();
+
+            app.AddElectronCookieProtection();
 
             app.UseEndpoints(endpoints =>
             {

--- a/src/Sidekick.Presentation.Blazor.Electron/Views/ViewLocator.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Views/ViewLocator.cs
@@ -10,6 +10,7 @@ using Sidekick.Domain.Settings;
 using Sidekick.Domain.Views;
 using Sidekick.Extensions;
 using Sidekick.Presentation.Blazor.Debounce;
+using Sidekick.Presentation.Blazor.Electron.App;
 
 namespace Sidekick.Presentation.Blazor.Electron.Views
 {
@@ -19,16 +20,19 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
         internal readonly IDebouncer debouncer;
         internal readonly ILogger<ViewLocator> logger;
         internal readonly ISidekickSettings settings;
+        internal readonly ElectronCookieProtection electronCookieProtection;
 
         public ViewLocator(IViewPreferenceRepository viewPreferenceRepository,
                            IDebouncer debouncer,
                            ILogger<ViewLocator> logger,
-                           ISidekickSettings settings)
+                           ISidekickSettings settings,
+                           ElectronCookieProtection electronCookieProtection)
         {
             this.viewPreferenceRepository = viewPreferenceRepository;
             this.debouncer = debouncer;
             this.logger = logger;
             this.settings = settings;
+            this.electronCookieProtection = electronCookieProtection;
         }
 
         private bool FirstView = true;
@@ -190,6 +194,8 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
 
             // Make sure the title is always Sidekick. For keybind management we are watching for this value.
             browserWindow.SetTitle("Sidekick");
+
+            await browserWindow.WebContents.Session.Cookies.SetAsync(electronCookieProtection.Cookie);
 
             var sidekickView = new SidekickView(this, view, viewType, browserWindow);
 


### PR DESCRIPTION
Since we use Electron.NET, it opens a random port on localhost starting from 8001. Which allows access to our Blazor app from a browser. I'm adding a cookie that acts as a pseudo anti-csrf cookie with a middleware.