### PR TITLE
Prevent calling getBounds after the view has been closed

### DIFF
--- a/src/Sidekick.Presentation.Blazor.Electron/Views/SidekickView.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Views/SidekickView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using ElectronNET.API;
 using Microsoft.Extensions.Logging;
 using Sidekick.Domain.Views;
@@ -7,8 +8,12 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
 {
     internal class SidekickView
     {
+        private CancellationTokenSource WindowResizeCancellationTokenSource { get; }
+
         public SidekickView(ViewLocator locator, View view, ViewType type, BrowserWindow browser)
         {
+            WindowResizeCancellationTokenSource = new CancellationTokenSource();
+
             Locator = locator;
             View = view;
             Type = type;
@@ -51,11 +56,12 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
                 {
                     Locator.logger.LogError("Failed to save the view size.", e);
                 }
-            });
+            }, WindowResizeCancellationTokenSource.Token, delay: 500);
         }
 
         private void Browser_OnClosed()
         {
+            WindowResizeCancellationTokenSource.Cancel();
             Locator.Views.Remove(this);
             Browser.OnReadyToShow -= Browser_OnReadyToShow;
             Browser.OnResize -= Browser_OnResize;

--- a/src/Sidekick.Presentation.Blazor/Debounce/Debouncer.cs
+++ b/src/Sidekick.Presentation.Blazor/Debounce/Debouncer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sidekick.Presentation.Blazor.Debounce
@@ -8,6 +9,7 @@ namespace Sidekick.Presentation.Blazor.Debounce
     {
         private readonly Dictionary<string, uint> Debounces = new Dictionary<string, uint>();
         public async Task Debounce(string id, Func<Task> func,
+            CancellationToken cancellationToken = new CancellationToken(),
             int refreshRate = 1000,
             int delay = 2000,
             Action<int> delayUpdate = null)
@@ -25,7 +27,7 @@ namespace Sidekick.Presentation.Blazor.Debounce
             var count = ++Debounces[id];
             while (delay > 0)
             {
-                await Task.Delay(refreshRate);
+                await Task.Delay(refreshRate, cancellationToken);
                 if (count != Debounces[id])
                 {
                     continue;

--- a/src/Sidekick.Presentation.Blazor/Debounce/IDebouncer.cs
+++ b/src/Sidekick.Presentation.Blazor/Debounce/IDebouncer.cs
@@ -1,10 +1,16 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Sidekick.Presentation.Blazor.Debounce
 {
     public interface IDebouncer
     {
-        Task Debounce(string id, Func<Task> func, int refreshRate = 1000, int delay = 2000, Action<int> delayUpdate = null);
+        Task Debounce(string id,
+                      Func<Task> func,
+                      CancellationToken cancellationToken = new CancellationToken(),
+                      int refreshRate = 1000,
+                      int delay = 2000,
+                      Action<int> delayUpdate = null);
     }
 }


### PR DESCRIPTION
Might be a better way to do this though.