### PR TITLE
Fix setup CascadingParameter error

### DIFF
--- a/src/Sidekick.Presentation.Blazor.Electron/Views/ViewLocator.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Views/ViewLocator.cs
@@ -85,7 +85,7 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
                 View.Settings => (800, 600),
                 View.Price => (1200, 660),
                 View.League => (800, 600),
-                View.Setup => (600, 700),
+                View.Setup => (600, 715),
                 View.Initialization => (400, 215),
                 View.Map => (500, 250),
                 _ => (800, 600),

--- a/src/Sidekick.Presentation.Blazor/Settings/Components/GameLanguageSelect.razor
+++ b/src/Sidekick.Presentation.Blazor/Settings/Components/GameLanguageSelect.razor
@@ -1,11 +1,12 @@
-@inherits MudSelect<string>
+@using System.Linq.Expressions;
 
 <MudSelect T="string"
            Label="@Resources.Language_Parser"
            Variant="Variant.Filled"
            Value="Value"
            For="For"
-           ValueChanged="ValueChanged">
+           ValueChanged="ValueChanged"
+           OffsetY="true">
     @foreach (var option in Options)
     {
         <MudSelectItem Value="@option.Key">@option.Value</MudSelectItem>
@@ -16,7 +17,11 @@
     [Inject] private SettingsResources Resources { get; set; }
     [Inject] private IMediator Mediator { get; set; }
 
-    private Dictionary<string, string> Options { get; set; }
+    [Parameter] public string Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public Expression<Func<string>> For { get; set; }
+
+    private Dictionary<string, string> Options { get; set; } = new Dictionary<string, string>();
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/Sidekick.Presentation.Blazor/Settings/Components/LeagueSelect.razor
+++ b/src/Sidekick.Presentation.Blazor/Settings/Components/LeagueSelect.razor
@@ -1,13 +1,13 @@
 @using Sidekick.Domain.Game.Leagues.Queries
-
-@inherits MudSelect<string>
+@using System.Linq.Expressions;
 
 <MudSelect T="string"
            Label="@Resources.Character_League"
            Variant="Variant.Filled"
            Value="Value"
            For="For"
-           ValueChanged="ValueChanged">
+           ValueChanged="ValueChanged"
+           OffsetY="true">
     @foreach (var option in Options)
     {
         <MudSelectItem Value="@option.Key">@option.Value</MudSelectItem>
@@ -17,6 +17,10 @@
 @code {
     [Inject] private SettingsResources Resources { get; set; }
     [Inject] private IMediator Mediator { get; set; }
+
+    [Parameter] public string Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public Expression<Func<string>> For { get; set; }
 
     private Dictionary<string, string> Options { get; set; } = new Dictionary<string, string>();
 

--- a/src/Sidekick.Presentation.Blazor/Settings/Components/UILanguageSelect.razor
+++ b/src/Sidekick.Presentation.Blazor/Settings/Components/UILanguageSelect.razor
@@ -1,11 +1,12 @@
-@inherits MudSelect<string>
+@using System.Linq.Expressions;
 
 <MudSelect T="string"
            Label="@Resources.Language_UI"
            Variant="Variant.Filled"
            Value="Value"
            For="For"
-           ValueChanged="ValueChanged">
+           ValueChanged="ValueChanged"
+           OffsetY="true">
     @foreach (var option in Options)
     {
         <MudSelectItem Value="@option.Key">@option.Value</MudSelectItem>
@@ -16,7 +17,11 @@
     [Inject] private SettingsResources Resources { get; set; }
     [Inject] private IMediator Mediator { get; set; }
 
-    private Dictionary<string, string> Options { get; set; }
+    [Parameter] public string Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+    [Parameter] public Expression<Func<string>> For { get; set; }
+
+    private Dictionary<string, string> Options { get; set; } = new Dictionary<string, string>();
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
For me f0bb6ca92cd48135f297951f62f12512eed9d9d6 still didn't fix the error.

- I'm still not sure exactly why the error happens, but it happens when **loading the leagues** in the `OnInitializedAsync` (which is why it only triggers on the first run since we already have the leagues in the database) in `LeagueSelect` after the initialization. Unlike the other dropdowns, this call is not instant.
- The offset makes it so the dropdown is below the current value, easier on the eyes when having multiples dropdowns:
![image](https://user-images.githubusercontent.com/4694217/109423885-53607480-79af-11eb-8ded-dce391cb28c3.png)
