### PR TITLE
Use LocalApplicationData path instead of the executable's path

### DIFF
--- a/src/Sidekick.Application/Settings/SaveSettingsHandler.cs
+++ b/src/Sidekick.Application/Settings/SaveSettingsHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
@@ -49,7 +50,8 @@ namespace Sidekick.Application.Settings
 
             var json = JsonSerializer.Serialize(settings);
             var defaults = JsonSerializer.Serialize(new SidekickSettings());
-            var filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), FileName);
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
+            var filePath = Path.Combine(sidekickPath, FileName);
 
             using var fileStream = File.Create(filePath);
             using var writer = new Utf8JsonWriter(fileStream, options: new JsonWriterOptions

--- a/src/Sidekick.Application/Settings/SaveSettingsHandler.cs
+++ b/src/Sidekick.Application/Settings/SaveSettingsHandler.cs
@@ -1,6 +1,4 @@
-using System;
 using System.IO;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,8 +48,7 @@ namespace Sidekick.Application.Settings
 
             var json = JsonSerializer.Serialize(settings);
             var defaults = JsonSerializer.Serialize(new SidekickSettings());
-            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
-            var filePath = Path.Combine(sidekickPath, FileName);
+            var filePath = SidekickPaths.GetDataFilePath(FileName);
 
             using var fileStream = File.Create(filePath);
             using var writer = new Utf8JsonWriter(fileStream, options: new JsonWriterOptions

--- a/src/Sidekick.Extensions/SidekickPaths.cs
+++ b/src/Sidekick.Extensions/SidekickPaths.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+
+namespace Sidekick.Extensions
+{
+    public static class SidekickPaths
+    {
+        public static string GetDataFilePath(string fileName)
+        {
+            // Possible solution for cross platform support
+            // var folderPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
+            return Path.Combine(Environment.ExpandEnvironmentVariables("%AppData%\\sidekick"), fileName);
+        }
+    }
+}

--- a/src/Sidekick.Logging/StartupExtensions.cs
+++ b/src/Sidekick.Logging/StartupExtensions.cs
@@ -1,12 +1,11 @@
 using System;
-using System.IO;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Sentry;
 using Serilog;
 using Sidekick.Domain.Settings;
+using Sidekick.Extensions;
 
 namespace Sidekick.Logging
 {
@@ -23,7 +22,7 @@ namespace Sidekick.Logging
                 .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Information)
                 .Enrich.FromLogContext()
-                .WriteTo.File(Path.Combine(sidekickPath, "Sidekick_log.log"),
+                .WriteTo.File(SidekickPaths.GetDataFilePath("Sidekick_log.log"),
                     rollingInterval: RollingInterval.Day,
                     retainedFileCountLimit: 1,
                     fileSizeLimitBytes: 5242880,

--- a/src/Sidekick.Logging/StartupExtensions.cs
+++ b/src/Sidekick.Logging/StartupExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
@@ -14,13 +15,15 @@ namespace Sidekick.Logging
     {
         public static IServiceCollection AddSidekickLogging(this IServiceCollection services, IConfiguration configuration, IHostEnvironment environment)
         {
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
+
             var logSink = new LogSink();
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", Serilog.Events.LogEventLevel.Information)
                 .Enrich.FromLogContext()
-                .WriteTo.File(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Sidekick_log.log"),
+                .WriteTo.File(Path.Combine(sidekickPath, "Sidekick_log.log"),
                     rollingInterval: RollingInterval.Day,
                     retainedFileCountLimit: 1,
                     fileSizeLimitBytes: 5242880,

--- a/src/Sidekick.Persistence/SidekickDesignTime.cs
+++ b/src/Sidekick.Persistence/SidekickDesignTime.cs
@@ -1,18 +1,15 @@
-using System;
-using System.IO;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Sidekick.Extensions;
+
 namespace Sidekick.Persistence
 {
     internal class SidekickDesignTime : IDesignTimeDbContextFactory<SidekickContext>
     {
         public SidekickContext CreateDbContext(string[] args)
         {
-            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
-
             var builder = new DbContextOptionsBuilder<SidekickContext>();
-            var connectionString = "Filename=" + Path.Combine(sidekickPath, "data.db");
+            var connectionString = "Filename=" + SidekickPaths.GetDataFilePath("data.db");
             builder.UseSqlite(connectionString);
             return new SidekickContext(builder.Options);
         }

--- a/src/Sidekick.Persistence/SidekickDesignTime.cs
+++ b/src/Sidekick.Persistence/SidekickDesignTime.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
@@ -8,8 +9,10 @@ namespace Sidekick.Persistence
     {
         public SidekickContext CreateDbContext(string[] args)
         {
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
+
             var builder = new DbContextOptionsBuilder<SidekickContext>();
-            var connectionString = "Filename=" + Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "data.db");
+            var connectionString = "Filename=" + Path.Combine(sidekickPath, "data.db");
             builder.UseSqlite(connectionString);
             return new SidekickContext(builder.Options);
         }

--- a/src/Sidekick.Persistence/StartupExtensions.cs
+++ b/src/Sidekick.Persistence/StartupExtensions.cs
@@ -1,12 +1,10 @@
-using System;
-using System.IO;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Sidekick.Domain.Apis.PoeNinja;
 using Sidekick.Domain.Cache;
 using Sidekick.Domain.Game.Leagues;
 using Sidekick.Domain.Views;
+using Sidekick.Extensions;
 using Sidekick.Persistence.Apis.PoeNinja;
 using Sidekick.Persistence.Cache;
 using Sidekick.Persistence.ItemCategories;
@@ -19,9 +17,7 @@ namespace Sidekick.Persistence
     {
         public static IServiceCollection AddSidekickPersistence(this IServiceCollection services)
         {
-            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
-
-            var connectionString = "Filename=" + Path.Combine(sidekickPath, "data.db");
+            var connectionString = "Filename=" + SidekickPaths.GetDataFilePath("data.db");
 
             services.AddDbContextPool<SidekickContext>(options => options.UseSqlite(connectionString));
 

--- a/src/Sidekick.Persistence/StartupExtensions.cs
+++ b/src/Sidekick.Persistence/StartupExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
@@ -18,7 +19,9 @@ namespace Sidekick.Persistence
     {
         public static IServiceCollection AddSidekickPersistence(this IServiceCollection services)
         {
-            var connectionString = "Filename=" + Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "data.db");
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
+
+            var connectionString = "Filename=" + Path.Combine(sidekickPath, "data.db");
 
             services.AddDbContextPool<SidekickContext>(options => options.UseSqlite(connectionString));
 

--- a/src/Sidekick.Presentation.Blazor.Electron/Program.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Program.cs
@@ -1,5 +1,5 @@
+using System;
 using System.IO;
-using System.Reflection;
 using ElectronNET.API;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -15,11 +15,14 @@ namespace Sidekick.Presentation.Blazor.Electron
             CreateHostBuilder(args).Build().Run();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
+
+            return Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration(config =>
                 {
-                    config.AddJsonFile(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), SaveSettingsHandler.FileName), true, true);
+                    config.AddJsonFile(Path.Combine(sidekickPath, SaveSettingsHandler.FileName), true, true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
@@ -27,5 +30,6 @@ namespace Sidekick.Presentation.Blazor.Electron
                         .UseElectron(args)
                         .UseStartup<Startup>();
                 });
+        }
     }
 }

--- a/src/Sidekick.Presentation.Blazor.Electron/Program.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Program.cs
@@ -1,10 +1,9 @@
-using System;
-using System.IO;
 using ElectronNET.API;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Sidekick.Application.Settings;
+using Sidekick.Extensions;
 
 namespace Sidekick.Presentation.Blazor.Electron
 {
@@ -17,12 +16,10 @@ namespace Sidekick.Presentation.Blazor.Electron
 
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
-            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
-
             return Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration(config =>
                 {
-                    config.AddJsonFile(Path.Combine(sidekickPath, SaveSettingsHandler.FileName), true, true);
+                    config.AddJsonFile(SidekickPaths.GetDataFilePath(SaveSettingsHandler.FileName), true, true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/src/Sidekick.Presentation.Blazor/Program.cs
+++ b/src/Sidekick.Presentation.Blazor/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
@@ -14,15 +15,19 @@ namespace Sidekick.Presentation.Blazor
             CreateHostBuilder(args).Build().Run();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
+
+            return Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration(config =>
                 {
-                    config.AddJsonFile(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), SaveSettingsHandler.FileName), true, true);
+                    config.AddJsonFile(Path.Combine(sidekickPath, SaveSettingsHandler.FileName), true, true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+        }
     }
 }

--- a/src/Sidekick.Presentation.Blazor/Program.cs
+++ b/src/Sidekick.Presentation.Blazor/Program.cs
@@ -1,10 +1,8 @@
-using System;
-using System.IO;
-using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Sidekick.Application.Settings;
+using Sidekick.Extensions;
 
 namespace Sidekick.Presentation.Blazor
 {
@@ -17,12 +15,10 @@ namespace Sidekick.Presentation.Blazor
 
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
-            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
-
             return Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration(config =>
                 {
-                    config.AddJsonFile(Path.Combine(sidekickPath, SaveSettingsHandler.FileName), true, true);
+                    config.AddJsonFile(SidekickPaths.GetDataFilePath(SaveSettingsHandler.FileName), true, true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/src/Sidekick.Presentation.Blazor/Startup.cs
+++ b/src/Sidekick.Presentation.Blazor/Startup.cs
@@ -9,8 +9,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Sidekick.Application;
+using Sidekick.Application.Settings;
 using Sidekick.Domain.Initialization.Commands;
 using Sidekick.Domain.Platforms;
+using Sidekick.Domain.Settings.Commands;
 using Sidekick.Domain.Views;
 using Sidekick.Infrastructure;
 using Sidekick.Localization;
@@ -105,6 +107,12 @@ namespace Sidekick.Presentation.Blazor
 
             Task.Run(async () =>
             {
+                await mediator.Send(new SaveSettingsCommand(new SidekickSettings()
+                {
+                    Language_Parser = "en",
+                    Language_UI = "en",
+                    LeagueId = "Ultimatum",
+                }, true));
                 await mediator.Send(new InitializeCommand(true));
             });
         }

--- a/tests/Sidekick.Application.Tests/MediatorFixture.cs
+++ b/tests/Sidekick.Application.Tests/MediatorFixture.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using MediatR;
@@ -12,6 +10,7 @@ using Sidekick.Domain.Initialization.Commands;
 using Sidekick.Domain.Platforms;
 using Sidekick.Domain.Settings.Commands;
 using Sidekick.Domain.Views;
+using Sidekick.Extensions;
 using Sidekick.Infrastructure;
 using Sidekick.Localization;
 using Sidekick.Logging;
@@ -36,10 +35,9 @@ namespace Sidekick.Application.Tests
         public async Task InitializeAsync()
         {
             var mockEnvironment = new Mock<IHostEnvironment>();
-            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
 
             var configuration = new ConfigurationBuilder()
-                .AddJsonFile(Path.Combine(sidekickPath, SaveSettingsHandler.FileName), true, true)
+                .AddJsonFile(SidekickPaths.GetDataFilePath(SaveSettingsHandler.FileName), true, true)
                 .Build();
 
             var services = new ServiceCollection()

--- a/tests/Sidekick.Application.Tests/MediatorFixture.cs
+++ b/tests/Sidekick.Application.Tests/MediatorFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -35,9 +36,10 @@ namespace Sidekick.Application.Tests
         public async Task InitializeAsync()
         {
             var mockEnvironment = new Mock<IHostEnvironment>();
+            var sidekickPath = Environment.ExpandEnvironmentVariables("%AppData%\\sidekick");
 
             var configuration = new ConfigurationBuilder()
-                .AddJsonFile(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), SaveSettingsHandler.FileName), true, true)
+                .AddJsonFile(Path.Combine(sidekickPath, SaveSettingsHandler.FileName), true, true)
                 .Build();
 
             var services = new ServiceCollection()


### PR DESCRIPTION
Fixes #565

Don't merge yet.

Use LocalApplicationData path instead of the executable's path to store persistent user data.

@leMicin This is a working fix, the data will be stored in `%AppData%\Roaming\sidekick` which is the same place where Electron seems to store webkit stuff (such as localStorage, sessionStorage, etc.). In theory it's actually a better location than using `%AppData%\Local\Programs\sidekick` that serves as the installation path.
Might want to decide if we want to add logic for debugging purposes and see how we handle the Test Project.