### PR TITLE
Limit Sentry error logging

### DIFF
--- a/src/Sidekick.Application/Game/Items/Parser/ParseItemHandler.cs
+++ b/src/Sidekick.Application/Game/Items/Parser/ParseItemHandler.cs
@@ -70,7 +70,7 @@ namespace Sidekick.Application.Game.Items.Parser
             }
             catch (Exception e)
             {
-                logger.LogError(e, "Could not parse item.");
+                logger.LogWarning(e, "Could not parse item.");
                 return null;
             }
         }

--- a/src/Sidekick.Infrastructure/PoeApi/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Infrastructure/PoeApi/Trade/TradeSearchService.cs
@@ -65,14 +65,14 @@ namespace Sidekick.Infrastructure.PoeApi.Trade
                 else
                 {
                     var responseMessage = await response?.Content?.ReadAsStringAsync();
-                    logger.LogError("Querying failed: {responseCode} {responseMessage}", response.StatusCode, responseMessage);
-                    logger.LogError("Uri: {uri}", uri);
-                    logger.LogError("Query: {query}", json);
+                    logger.LogWarning("Querying failed: {responseCode} {responseMessage}", response.StatusCode, responseMessage);
+                    logger.LogWarning("Uri: {uri}", uri);
+                    logger.LogWarning("Query: {query}", json);
                 }
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Exception thrown while querying trade api.");
+                logger.LogWarning(ex, "Exception thrown while querying trade api.");
             }
 
             return null;
@@ -144,14 +144,14 @@ namespace Sidekick.Infrastructure.PoeApi.Trade
                 else
                 {
                     var responseMessage = await response?.Content?.ReadAsStringAsync();
-                    logger.LogError("Querying failed: {responseCode} {responseMessage}", response.StatusCode, responseMessage);
-                    logger.LogError("Uri: {uri}", uri);
-                    logger.LogError("Query: {query}", json);
+                    logger.LogWarning("Querying failed: {responseCode} {responseMessage}", response.StatusCode, responseMessage);
+                    logger.LogWarning("Uri: {uri}", uri);
+                    logger.LogWarning("Query: {query}", json);
                 }
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Exception thrown while querying trade api.");
+                logger.LogWarning(ex, "Exception thrown while querying trade api.");
             }
 
             return null;
@@ -325,7 +325,7 @@ namespace Sidekick.Infrastructure.PoeApi.Trade
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, $"Exception thrown when fetching trade API listings from Query {queryId}.");
+                logger.LogWarning(ex, $"Exception thrown when fetching trade API listings from Query {queryId}.");
             }
 
             return null;

--- a/src/Sidekick.Infrastructure/PoePriceInfo/PoePriceInfoClient.cs
+++ b/src/Sidekick.Infrastructure/PoePriceInfo/PoePriceInfoClient.cs
@@ -12,6 +12,7 @@ namespace Sidekick.Infrastructure.PoePriceInfo
             Client.BaseAddress = new Uri("https://www.poeprices.info/api");
             Client.DefaultRequestHeaders.TryAddWithoutValidation("X-Powered-By", "Sidekick");
             Client.DefaultRequestHeaders.UserAgent.TryParseAdd("Sidekick");
+            Client.Timeout = TimeSpan.FromSeconds(10);
             Options = new JsonSerializerOptions()
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase

--- a/src/Sidekick.Platform.Windows/Processes/ProcessProvider.cs
+++ b/src/Sidekick.Platform.Windows/Processes/ProcessProvider.cs
@@ -151,7 +151,7 @@ namespace Sidekick.Platform.Windows.Processes
                     }
                     catch (Exception e)
                     {
-                        logger.LogError(e, localizer["AdminError"]);
+                        logger.LogWarning(e, localizer["AdminError"]);
                     }
                     finally
                     {
@@ -201,7 +201,7 @@ namespace Sidekick.Platform.Windows.Processes
             }
             catch (Exception e)
             {
-                logger.LogError(e, e.Message);
+                logger.LogWarning(e, e.Message);
             }
 
             return result;

--- a/src/Sidekick.Presentation.Blazor.Electron/Tray/TrayProvider.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Tray/TrayProvider.cs
@@ -91,7 +91,7 @@ namespace Sidekick.Presentation.Blazor.Electron.Tray
             }
             catch (Exception e)
             {
-                logger.LogError("Exception while initializing the tray.", e);
+                logger.LogError(e, "Exception while initializing the tray.");
             }
         }
 

--- a/src/Sidekick.Presentation.Blazor.Electron/Views/InternalViewInstance.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Views/InternalViewInstance.cs
@@ -67,7 +67,7 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
                 }
                 catch (Exception e)
                 {
-                    Locator.logger.LogWarning("Failed to save the view size.", e);
+                    Locator.logger.LogWarning(e, "Failed to save the view size.");
                 }
             }, WindowResizeCancellationTokenSource.Token, delay: 500);
         }

--- a/src/Sidekick.Presentation.Blazor.Electron/Views/InternalViewInstance.cs
+++ b/src/Sidekick.Presentation.Blazor.Electron/Views/InternalViewInstance.cs
@@ -67,7 +67,7 @@ namespace Sidekick.Presentation.Blazor.Electron.Views
                 }
                 catch (Exception e)
                 {
-                    Locator.logger.LogError("Failed to save the view size.", e);
+                    Locator.logger.LogWarning("Failed to save the view size.", e);
                 }
             }, WindowResizeCancellationTokenSource.Token, delay: 500);
         }

--- a/src/Sidekick.Presentation.Blazor/Trade/Components/Prices/PricePredictionComponent.razor
+++ b/src/Sidekick.Presentation.Blazor/Trade/Components/Prices/PricePredictionComponent.razor
@@ -1,3 +1,7 @@
+@using System.Threading
+ 
+@implements IDisposable
+
 @using Sidekick.Domain.Apis.PoePriceInfo.Queries
 @using Sidekick.Domain.Apis.PoePriceInfo.Models
 @using Sidekick.Domain.Settings
@@ -35,6 +39,7 @@
     private bool Loading { get; set; }
     private bool IsInit { get; set; }
     private PricePrediction Prediction { get; set; }
+    private CancellationTokenSource pricePredictionCancellationTokenSource = new CancellationTokenSource();
 
     protected override async Task OnParametersSetAsync()
     {
@@ -47,9 +52,14 @@
         if (Item != null)
         {
             IsInit = true;
-            Prediction = await Mediator.Send(new GetPricePredictionQuery(Item));
+            Prediction = await Mediator.Send(new GetPricePredictionQuery(Item), pricePredictionCancellationTokenSource.Token);
         }
 
         Loading = false;
+    }
+
+    public void Dispose()
+    {
+        pricePredictionCancellationTokenSource.Cancel();
     }
 }


### PR DESCRIPTION
Fixes #579.
Limit what is considered as an error:
- API requests and errors
- poeprices.info requests
- ProcessProvider access
- Item parser failing
- LastWhisper handler

Also add poeprices.info try/catch and timeout.