### PR TITLE
Fix culture change

### DIFF
--- a/src/Sidekick.Application/Localization/SetUiLanguageHandler.cs
+++ b/src/Sidekick.Application/Localization/SetUiLanguageHandler.cs
@@ -28,8 +28,8 @@ namespace Sidekick.Application.Localization
 
             if (!string.IsNullOrEmpty(name))
             {
-                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(request.Name);
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(request.Name);
+                CultureInfo.DefaultThreadCurrentCulture = CultureInfo.GetCultureInfo(request.Name);
+                CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo(request.Name);
             }
 
             return Unit.Value;


### PR DESCRIPTION
Fixes #603

Blazor has a special way of handling culture; by cookie, request, or state. We have to force the default culture instead since we don't do any of that.