### PR TITLE
Fix parsing Metamorph Sample and Captured Beast

### DIFF
--- a/src/Sidekick.Infrastructure/PoeApi/Items/Metadatas/ItemMetadataProvider.cs
+++ b/src/Sidekick.Infrastructure/PoeApi/Items/Metadatas/ItemMetadataProvider.cs
@@ -225,6 +225,13 @@ namespace Sidekick.Infrastructure.PoeApi.Items.Metadatas
                 {
                     result.Rarity = itemRarity;
                 }
+
+                if (result.Category == Category.ItemisedMonster && result.Rarity == Rarity.Unique && string.IsNullOrEmpty(result.Name))
+                {
+                    result.Name = name;
+                }
+
+
             }
 
             return result;

--- a/src/Sidekick.Infrastructure/PoeApi/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Infrastructure/PoeApi/Trade/TradeSearchService.cs
@@ -102,7 +102,18 @@ namespace Sidekick.Infrastructure.PoeApi.Trade
                     };
                 }
 
-                if (item.Metadata.Rarity == Rarity.Unique)
+                if (item.Metadata.Category == Category.ItemisedMonster)
+                {
+                    if (!string.IsNullOrEmpty(item.Metadata.Name))
+                    {
+                        request.Query.Term = item.Metadata.Name;
+                    }
+                    else if (!string.IsNullOrEmpty(item.Metadata.Type))
+                    {
+                        request.Query.Type = item.Metadata.Type;
+                    }
+                }
+                else if (item.Metadata.Rarity == Rarity.Unique)
                 {
                     request.Query.Name = item.Metadata.Name;
                     request.Query.Type = item.Metadata.Type;

--- a/src/Sidekick.Infrastructure/PoeNinja/GetPriceFromNinjaHandler.cs
+++ b/src/Sidekick.Infrastructure/PoeNinja/GetPriceFromNinjaHandler.cs
@@ -61,6 +61,7 @@ namespace Sidekick.Infrastructure.PoeNinja
                     case Category.Jewel: fetchItems.Add(poeNinjaClient.FetchItems(ItemType.UniqueJewel)); break;
                     case Category.Map: fetchItems.Add(poeNinjaClient.FetchItems(ItemType.UniqueMap)); break;
                     case Category.Weapon: fetchItems.Add(poeNinjaClient.FetchItems(ItemType.UniqueWeapon)); break;
+                    case Category.ItemisedMonster: fetchItems.Add(poeNinjaClient.FetchItems(ItemType.Beast)); break;
                 }
             }
             else

--- a/src/Sidekick.Persistence/Apis/PoeNinja/PoeNinjaRepository.cs
+++ b/src/Sidekick.Persistence/Apis/PoeNinja/PoeNinjaRepository.cs
@@ -22,6 +22,8 @@ namespace Sidekick.Persistence.Apis.PoeNinja
             using var dbContext = new SidekickContext(options);
 
             var name = item.Original.Name;
+            var type = item.Original.Type;
+
             var translation = await dbContext.NinjaTranslations.FirstOrDefaultAsync(x => x.Translation == name);
             if (translation != null)
             {
@@ -29,7 +31,7 @@ namespace Sidekick.Persistence.Apis.PoeNinja
             }
 
             var query = dbContext.NinjaPrices
-                .Where(x => x.Name == name);
+                .Where(x => x.Name == name || x.Name == type);
 
             if (item.Properties != null)
             {

--- a/tests/Sidekick.Application.Tests/Game/Items/Parser/MiscParsing.cs
+++ b/tests/Sidekick.Application.Tests/Game/Items/Parser/MiscParsing.cs
@@ -45,8 +45,30 @@ namespace Sidekick.Application.Tests.Game.Items.Parser
 
             Assert.Equal(Category.ItemisedMonster, actual.Metadata.Category);
             Assert.Equal(Rarity.Unique, actual.Metadata.Rarity);
-            Assert.Null(actual.Metadata.Name);
+            Assert.Equal("Portentia, the Foul's Heart", actual.Metadata.Name);
             Assert.Equal("Portentia, the Foul", actual.Metadata.Type);
+        }
+
+        [Fact]
+        public async Task ParseRareBeast()
+        {
+            var parsedRareBeast = await mediator.Send(new ParseItemCommand(RareBeast));
+
+            Assert.Equal(Category.ItemisedMonster, parsedRareBeast.Metadata.Category);
+            Assert.Equal(Rarity.Rare, parsedRareBeast.Metadata.Rarity);
+            Assert.Null(parsedRareBeast.Metadata.Name);
+            Assert.Equal("Farric Tiger Alpha", parsedRareBeast.Metadata.Type);
+        }
+
+        [Fact]
+        public async Task ParseUniqueBeast()
+        {
+            var parsedRareBeast = await mediator.Send(new ParseItemCommand(UniqueBeast));
+
+            Assert.Equal(Category.ItemisedMonster, parsedRareBeast.Metadata.Category);
+            Assert.Equal(Rarity.Unique, parsedRareBeast.Metadata.Rarity);
+            Assert.Equal("Saqawal, First of the Sky", parsedRareBeast.Metadata.Name);
+            Assert.Equal("Saqawal, First of the Sky", parsedRareBeast.Metadata.Type);
         }
 
         #region ItemText
@@ -74,7 +96,7 @@ Right click this item then left click a magic, rare or unique item to apply it.
 Shift click to unstack.
 ";
 
-        private const string Organ = @"Item Class: Unknown
+        private const string Organ = @"Item Class: Metamorph Sample
 Rarity: Unique
 Portentia, the Foul's Heart
 --------
@@ -88,6 +110,39 @@ Drops additional Rare Armour
 Drops additional Rare Jewellery
 --------
 Combine this with four other different samples in Tane's Laboratory.";
+
+        private const string RareBeast = @"Item Class: Stackable Currency
+Rarity: Rare
+Foulface the Ravager
+Farric Tiger Alpha
+--------
+Genus: Tigers
+Group: Felines
+Family: The Wilds
+--------
+Item Level: 82
+--------
+Tiger Prey
+Spectral Swipe
+Accurate
+Evasive
+Gains Endurance Charges
+--------
+Right-click to add this to your bestiary.";
+
+        private const string UniqueBeast = @"Item Class: Stackable Currency
+Rarity: Unique
+Saqawal, First of the Sky
+--------
+Genus: Rhexes
+Group: Avians
+Family: The Sands
+--------
+Item Level: 70
+--------
+Cannot be fully Slowed
+--------
+Right-click to add this to your bestiary.";
         #endregion
     }
 }


### PR DESCRIPTION
- Added some unit tests for parsing Metamorph Sample and captured beast , change some text due to latest changes in POE

This could have been easier if we "Item Class"  parsed 😄 . For the time being, I am kind of trusting everything copied from the game right now.

Limitations:
- It seems POE Trade API returns null hashes for both Captured Beast and Metamorph Sample explicit mods. As we are using hashes for now -> No showing explicit mods
- Price prediction for poeprice.info does not allow non-rare items using API for now , which should have helped with organs price prediction

Would be nice if someone could tested with other language, I have only tested with English so far
